### PR TITLE
Fix citation hashing

### DIFF
--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -55,14 +55,6 @@ class Citation:
         self.match_url = match_url
         self.match_id = match_id
 
-        self.equality_attributes = [
-            "reporter",
-            "volume",
-            "page",
-            "canonical_reporter",
-            "lookup_index",
-        ]
-
     def as_regex(self):
         pass
 
@@ -94,20 +86,8 @@ class Citation:
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def fuzzy_hash(self):
-        """Used to test equality in dicts.
-
-        Overridden here to simplify away some of the attributes that can differ
-        for the same citation.
-        """
-        str_to_hash = ""
-        for attr in self.equality_attributes:
-            str_to_hash += str(getattr(self, attr, None))
-        return hash(str_to_hash)
-
-    def fuzzy_eq(self, other):
-        """Used to override the __eq__ function."""
-        return self.fuzzy_hash() == other.fuzzy_hash()
+    def __hash__(self):
+        return hash(tuple(self.__dict__.values()))
 
 
 class FullCitation(Citation):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = ["legal", "courts"]
 license = "BSD-2-Clause"
 maintainers = ["Free Law Project <info@free.law>"]
 name = "eyecite"
-readme = "README.md"
+readme = "README.rst"
 repository = "https://github.com/freelawproject/eyecite"
 version = "1.0.0"
 

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from eyecite.models import Citation
+
+
+class ModelsTest(TestCase):
+    def test_comparison(self):
+        """Are two citation objects equal when their attributes are
+        the same?"""
+        citations = [
+            Citation(reporter=2, volume="U.S.", page="2", reporter_index=2),
+            Citation(reporter=2, volume="U.S.", page="2", reporter_index=2),
+        ]
+        print("Testing citation comparison...", end=" ")
+        self.assertEqual(citations[0], citations[1])
+        self.assertEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")


### PR DESCRIPTION
I realized that I forgot to transfer the test for citation hashing from CL to this repo. But, as I was doing so, I also realized that our implementation of `Citation.fuzzy_hash()` is confusing and liable to cause errors for those not familiar with its origin.

See the [Python docs](https://docs.python.org/3/reference/datamodel.html#object.__hash__) on this matter:

> If a class does not define an \_\_eq\_\_() method it should not define a \_\_hash\_\_() operation either; if it defines \_\_eq\_\_() but not \_\_hash\_\_(), its instances will not be usable as items in hashable collections.

Currently, we implement `__eq__()` but not `__hash__()`, meaning that `Citation` objects cannot be used in hashable collections (as the docs warn). Thus, if the user were to do something like `citation1 in set(citation2, citation3)`, they will get a `TypeError: unhashable type: 'Citation'` error. This is because each object's `__hash__()` method is currently `None`. (Note that if we didn't implement `__eq__()`, `__hash__()` would be defined natively.)

To me, the solution seems to simply make our `fuzzy_hash()` method the default `__hash__()` function. If the user doesn't like that for some reason, they can always override it. But otherwise, I don't think it makes any sense to only implement `__eq__()` and not `__hash__()`. (Another solution would be to remove both implementations, as currently the `fuzzy_hash()`method isn't doing anything in this package.)

Finally, it also seems to me that if we do this, it also makes no sense for `__eq__()` to test a different set of attributes than `__hash__()`. When would we expect two citations to not equal each other but hash to the same value?

Happy to discuss. N.B., I also had to change the README file name (d165445) in order for the tests to pass. (Though I don't understand how they passed on master without making this fix.)