### PR TITLE
Tokenizer emits token objects instead of strings

### DIFF
--- a/eyecite/find_citations.py
+++ b/eyecite/find_citations.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterable, List, Optional, Sequence, Union, cast
+from typing import Callable, Iterable, List, Optional, Union, cast
 
 from eyecite.helpers import (
     add_defendant,
@@ -22,7 +22,8 @@ from eyecite.reporter_tokenizer import (
     ReporterToken,
     SectionToken,
     SupraToken,
-    Token,
+    TokenOrStr,
+    Tokens,
     tokenize,
 )
 from eyecite.utils import clean_text, strip_punct
@@ -34,7 +35,7 @@ def get_citations(
     do_defendant: bool = True,
     remove_ambiguous: bool = False,
     clean: Iterable[Union[str, Callable[[str], str]]] = ("whitespace",),
-    tokenizer: Callable[[str], Iterable[Token]] = tokenize,
+    tokenizer: Callable[[str], Iterable[TokenOrStr]] = tokenize,
 ) -> Iterable[Union[NonopinionCitation, Citation]]:
     """Main function"""
     if text == "this":
@@ -116,7 +117,7 @@ def get_citations(
 
 
 def extract_full_citation(
-    words: Sequence[Token],
+    words: Tokens,
     reporter_index: int,
 ) -> Optional[FullCitation]:
     """Given a list of words and the index of a federal reporter, look before
@@ -175,7 +176,7 @@ def extract_full_citation(
 
 
 def extract_shortform_citation(
-    words: Sequence[Token],
+    words: Tokens,
     reporter_index: int,
 ) -> Optional[ShortformCitation]:
     """Given a list of words and the index of a federal reporter, look before
@@ -237,7 +238,7 @@ def extract_shortform_citation(
 
 
 def extract_supra_citation(
-    words: Sequence[Token],
+    words: Tokens,
     supra_index: int,
 ) -> Optional[SupraCitation]:
     """Given a list of words and the index of a supra token, look before
@@ -275,7 +276,7 @@ def extract_supra_citation(
 
 
 def extract_id_citation(
-    words: Sequence[Token],
+    words: Tokens,
     id_index: int,
 ) -> Optional[IdCitation]:
     """Given a list of words and the index of an id token, gather the

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional, Sequence, Union, cast
+from typing import List, Optional, Union, cast
 
 from courts_db import courts
 
@@ -9,7 +9,12 @@ from eyecite.models import (
     NonopinionCitation,
     ShortformCitation,
 )
-from eyecite.reporter_tokenizer import ReporterToken, StopWordToken, Token
+from eyecite.reporter_tokenizer import (
+    ReporterToken,
+    StopWordToken,
+    TokenOrStr,
+    Tokens,
+)
 from eyecite.utils import is_roman, strip_punct
 
 FORWARD_SEEK = 20
@@ -51,7 +56,7 @@ def get_court_by_paren(paren_string: str, citation: Citation) -> Optional[str]:
     return court_code
 
 
-def get_year(token: Token) -> Optional[int]:
+def get_year(token: TokenOrStr) -> Optional[int]:
     """Given a string token, look for a valid 4-digit number at the start and
     return its value.
     """
@@ -69,7 +74,7 @@ def get_year(token: Token) -> Optional[int]:
     return year
 
 
-def add_post_citation(citation: Citation, words: Sequence[Token]) -> None:
+def add_post_citation(citation: Citation, words: Tokens) -> None:
     """Add to a citation object any additional information found after the base
     citation, including court, year, and possibly page range.
 
@@ -115,7 +120,7 @@ def add_post_citation(citation: Citation, words: Sequence[Token]) -> None:
             break
 
 
-def add_defendant(citation: Citation, words: Sequence[Token]) -> None:
+def add_defendant(citation: Citation, words: Tokens) -> None:
     """Scan backwards from 2 tokens before reporter until you find v., in re,
     etc. If no known stop-token is found, no defendant name is stored.  In the
     future, this could be improved.

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -1,4 +1,49 @@
 import re
+from datetime import datetime
+from typing import Optional
+
+
+class Reporter:
+    """Class for top-level reporters in reporters_db, like "S.W." """
+
+    def __init__(self, short_name: str, name: str, cite_type: str):
+        self.short_name = short_name
+        self.name = name
+        self.cite_type = cite_type
+        self.is_scotus = (
+            self.cite_type == "federal" and "supreme" in self.name.lower()
+        ) or "scotus" in self.cite_type.lower()
+        self.is_neutral_tc_reporter = re.match(
+            r"T\. ?C\. (Summary|Memo)", short_name
+        )
+
+
+class Edition:
+    """Class for individual editions in reporters_db,
+    like "S.W." and "S.W.2d"."""
+
+    def __init__(
+        self,
+        reporter: Reporter,
+        short_name: str,
+        start: Optional[datetime],
+        end: Optional[datetime],
+    ):
+        self.reporter = reporter
+        self.short_name = short_name
+        self.start = start
+        self.end = end
+
+    def includes_year(
+        self,
+        year: int,
+    ) -> bool:
+        """Return True if edition contains cases for the given year."""
+        return (
+            year <= datetime.now().year
+            and (self.start is None or self.start.year <= year)
+            and (self.end is None or self.end.year >= year)
+        )
 
 
 class Citation:
@@ -12,7 +57,6 @@ class Citation:
         page,
         volume,
         canonical_reporter=None,
-        lookup_index=None,
         extra=None,
         defendant=None,
         plaintiff=None,
@@ -22,6 +66,9 @@ class Citation:
         match_id=None,
         reporter_found=None,
         reporter_index=None,
+        all_editions=None,
+        exact_editions=None,
+        variation_editions=None,
     ):
 
         # Core data.
@@ -32,7 +79,6 @@ class Citation:
         # These values are set during disambiguation.
         # For a citation to F.2d, the canonical reporter is F.
         self.canonical_reporter = canonical_reporter
-        self.lookup_index = lookup_index
 
         # Supplementary data, if possible.
         self.extra = extra
@@ -54,6 +100,16 @@ class Citation:
         # Attributes of the matching item, for URL generation.
         self.match_url = match_url
         self.match_id = match_id
+
+        # List of reporter models that may match this reporter string
+        self.all_editions = tuple(all_editions) if all_editions else tuple()
+        self.exact_editions = (
+            tuple(exact_editions) if all_editions else tuple()
+        )
+        self.variation_editions = (
+            tuple(variation_editions) if all_editions else tuple()
+        )
+        self.edition_guess: Optional[Edition] = None
 
     def as_regex(self):
         pass
@@ -88,6 +144,29 @@ class Citation:
 
     def __hash__(self):
         return hash(tuple(self.__dict__.values()))
+
+    def guess_edition(self):
+        """Set canonical_reporter, edition_guess, and reporter."""
+        # Use exact matches if possible, otherwise try variations
+        editions = self.exact_editions or self.variation_editions
+        if not editions:
+            return
+
+        # Attempt resolution by date
+        if len(editions) > 1 and self.year:
+            editions = [e for e in editions if e.includes_year(self.year)]
+
+        if len(editions) == 1:
+            self.edition_guess = editions[0]
+            self.canonical_reporter = editions[0].reporter.short_name
+            self.reporter = editions[0].short_name
+
+    def guess_court(self):
+        """Set court based on reporter."""
+        if not self.court and any(
+            e.reporter.is_scotus for e in self.all_editions
+        ):
+            self.court = "scotus"
 
 
 class FullCitation(Citation):

--- a/eyecite/reporter_tokenizer.py
+++ b/eyecite/reporter_tokenizer.py
@@ -2,19 +2,106 @@
 # URL: <http://nltk.sourceforge.net>
 
 import re
-from typing import List
+from collections import UserString, defaultdict
+from typing import List, Set
 
-from eyecite.helpers import REPORTER_STRINGS
+from reporters_db import EDITIONS, REPORTERS, VARIATIONS_ONLY
+
+from eyecite.models import Edition, Reporter
+
+# Build lookups that match reporter strings like "U.S."
+# or "U. S." to Edition objects:
+EDITIONS_LOOKUP = defaultdict(list)
+VARIATIONS_LOOKUP = defaultdict(list)
+for reporter_key, reporter_cluster in REPORTERS.items():
+    for reporter in reporter_cluster:
+        reporter_obj = Reporter(
+            short_name=reporter_key,
+            name=reporter["name"],
+            cite_type=reporter["cite_type"],
+        )
+        editions = {}
+        for k, v in reporter["editions"].items():
+            editions[k] = Edition(
+                short_name=k,
+                reporter=reporter_obj,
+                start=v["start"],
+                end=v["end"],
+            )
+            EDITIONS_LOOKUP[k].append(editions[k])
+        for k, v in reporter["variations"].items():
+            VARIATIONS_LOOKUP[k].append(editions[v])
+
 
 # We need to build a REGEX that has all the variations and the reporters in
 # order from longest to shortest.
 
+REPORTER_STRINGS: Set[str] = set(
+    list(EDITIONS.keys()) + list(VARIATIONS_ONLY.keys())
+)
 REGEX_LIST = sorted(REPORTER_STRINGS, key=len, reverse=True)
 REGEX_STR = "|".join(map(re.escape, REGEX_LIST))
 REPORTER_RE = re.compile(r"(^|\s)(%s)(\s|,)" % REGEX_STR)
 
+STOP_TOKENS = {
+    "v",
+    "re",
+    "parte",
+    "denied",
+    "citing",
+    "aff'd",
+    "affirmed",
+    "remanded",
+    "see",
+    "granted",
+    "dismissed",
+}
 
-def tokenize(text: str) -> List[str]:
+
+class Token(UserString):
+    """ Any word in the tokenized case, not otherwise identified. """
+
+    def __repr__(self):
+        return f"{type(self).__name__}({repr(self.data)})"
+
+
+class ReporterToken(Token):
+    """ Words in the case that refer to a reporter string, such as "U. S." """
+
+    def __init__(self, s, editions, variations):
+        # Track editions where we have an exact string match, like "U.S.",
+        # separately from editions that match a variation, like "U. S."
+        self.exact_editions = editions
+        self.variation_editions = variations
+        self.all_editions = editions + variations
+        super().__init__(s)
+
+
+class SectionToken(Token):
+    """ Word containing a section symbol. """
+
+    pass
+
+
+class SupraToken(Token):
+    """ Word matching "supra" with or without punctuation. """
+
+    pass
+
+
+class IdToken(Token):
+    """ Word matching "id" or "ibid". """
+
+    pass
+
+
+class StopWordToken(Token):
+    """ Word matching one of the STOP_TOKENS. """
+
+    pass
+
+
+def tokenize(text: str) -> List[Token]:
     """Tokenize text using regular expressions in the following steps:
      - Split the text by the occurrences of patterns which match a federal
        reporter, including the reporter strings as part of the resulting
@@ -29,14 +116,42 @@ def tokenize(text: str) -> List[str]:
     # if the text looks likes the corner-case 'digit-REPORTER-digit', splitting
     # by spaces doesn't work
     if re.match(r"\d+\-[A-Za-z]+\-\d+", text):
-        return text.split("-")
+        parts = text.split("-")
+        reporter = ReporterToken(
+            parts[1],
+            editions=EDITIONS_LOOKUP.get(parts[1], []),
+            variations=VARIATIONS_LOOKUP.get(parts[1], []),
+        )
+        return [Token(parts[0]), reporter] + [
+            Token(part) for part in parts[2:]
+        ]
     # otherwise, we just split on spaces to find words
     strings = REPORTER_RE.split(text)
-    words = []
+    tokens: List[Token] = []
     for string in strings:
         if string in REPORTER_STRINGS:
-            words.append(string)
+            tokens.append(
+                ReporterToken(
+                    string,
+                    editions=EDITIONS_LOOKUP.get(string, []),
+                    variations=VARIATIONS_LOOKUP.get(string, []),
+                )
+            )
         else:
-            # Normalize spaces
-            words.extend(string.strip().split())
-    return words
+            for word in string.strip().split():
+                token: Token
+                stripped_word = re.sub(
+                    r"^[^a-z0-9]*|[^a-z0-9]*$", "", word.lower()
+                )
+                if word.lower() in {"id.", "id.,", "ibid."}:
+                    token = IdToken(word)
+                elif stripped_word == "supra":
+                    token = SupraToken(word)
+                elif stripped_word in STOP_TOKENS:
+                    token = StopWordToken(word)
+                elif "§" in word:
+                    token = SectionToken(word)
+                else:
+                    token = Token(word)
+                tokens.append(token)
+    return tokens


### PR DESCRIPTION
I apologize that this is a large PR, both as far as being hard to review and being a big change to propose. Happy to back things out if they don't seem right, or to otherwise help with review.

## Intro

The core idea here is it would be nice if I could plug in a different tokenizer that has a different idea of what a reporter string is. In particular, because CAP comes from OCR, we have a certain amount of vagueness about distinguishing periods, commas, dashes, single-quotes, and specks of dust. So we'd like to recognize "1 U.'S, 1" as a citation, but still take advantage of the disambiguation and other stuff eyecite does.

How do we do that? Suppose instead of the tokenizer emitting `["1", "U.S.", "1"]`, it emits `[Token("1"), ReporterToken("U.S.", editions=[us_edition]), Token("1")]` -- that is, it's the tokenizer's job not just to say "this chunk is a reporter," which it does already, but also "these are the editions it might be referring to." The post-processing code then just checks that attribute instead of doing a new lookup based on the matched string, and you can drop in different tokenizers and everything works.

This complicates things a bit internally, but less than you would think. Downside is we add a class hierarchy of tokens, and have to have the tokenizer wrap things in `Token` and the post-processing code call `str()` when it needs plain strings. But it simplifies things too, because we can just calculate things once per token instead of looking it up over and over. So my hope is in addition to solving CAP's usecase (and other usecases like allowing the caller to plug in hyperscan if they want), this also pays for itself in simplicity. At least lines of code didn't increase much. :)

## Details

Specific changes in the diff:

* `get_citations()` now takes a `tokenizer` function that defaults to the built-in `tokenize`. See the test for an example.
* Add two models: `Reporter` that maps to the top-level reporters in reporters-db, like the set of "S.W" editions, and `Edition` that maps to "S.W.", "S.W.2d" etc. Each Edition points to its Reporter.
  * Are those the correct names for those concepts? Reporter means a million things here.
* In reporter_tokenizer.py, build an `EDITIONS_LOOKUP` from official reporter string to Edition object, and `VARIATIONS_LOOKUP` from variation string to Edition object. We have to keep these separate so we can preferentially resolve ambiguous reporters to an exact match instead of a variation.
* In reporter_tokenizer.py, define classes for each kind of token we check for later in the code -- Token, ReporterToken, SectionToken, SupraToken, IdToken, StopWordToken. These are all just bare UserString subclasses (meaning they have `str()`, `__eq__`, `len()` etc. based on their string value, and other than that they only vary by type), except for ReporterToken. ReporterToken also tracks its exact_editions (like EDITIONS_LOOKUP["U.S."]), its variation_editions (like VARIATIONS_LOOKUP["U. S."]), and all_editions (both combined).
  *  For review: the token classes could also live in models.py.
* tokenize() emits a list of those tokens instead of a list of strings.
* get_citations() checks the types of tokens instead of inspecting the strings directly.
* When creating a `Citation`, the `exact_editions`, `variation_editions`, and `all_editions` values are copied over to the citation from the `ReporterToken`, so we can use them for disambiguation or the user can use them for their own disambiguation later.
* Disambiguating: `disambiguate_reporters` can now be split into two jobs. Right after the citation and context are extracted, we call `guess_edition` to try to narrow down multiple editions to one on *all* citations (because why not). This sets `edition_guess`. Then if the `remove_ambiguous` parameter is true, we strip out all citations where the number couldn't be reduced to one.
  * For review: in writing `models.Citation.guess_edition()` I used a shorter algorithm than the existing `disambiguate_reporters`. Pretty much just: `editions = self.exact_editions or self.variation_editions`; strip editions where the year excludes the edition; if one edition remains, that's our guess. All the tests pass with this approach, but let me know if this leaves out a nuance of the existing code.
  * For review: we no longer set `lookup_index`. I think that was an implementation detail that is no longer needed. LMK if it was serving some other purpose.
  * For review: one functional difference is I think the existing code checks dates by seeing if "1 S.W.2d 1 (1900)" falls in the date range for *any* S.W. reporter, and my new code only checks the dates for S.W.2d. That seems right to me?
* There's a bit of refactoring around is_scotus and is_neutral_tc_reporter, since those can now be booleans on the Reporter object.
* Tests:
  * I restricted the test to only checking a set list of attributes in `match_attrs`, so I wouldn't have to edit every test case with all the `*_editions` attributes for now. I can add those later if this all seems OK and we want them in.
  * Add a very simple custom tokenizer test.

## Left undone

We might want to revisit what we're exposing as far as the exact matched string, the guess about the corrected reporter string, the guess about the canonical reporter string, and the various reporter objects I'm now attaching. I didn't change any of the existing values, but maybe worth clarifying the terminology and removing redundancy once the dust settles.