### PR TITLE
fix(tokenizer): Matches citations across line breaks.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ You can use :code:`clean_text` to help with this:
     from eyecite import clean_text, get_citations
 
     source_text = '<p>foo   1  U.S.  1   </p>'
-    plain_text = clean_text(text, ['html', 'whitespace', my_func])
+    plain_text = clean_text(text, ['html', 'inline_whitespace', my_func])
     found_citations = get_citations(plain_text)
 
 See the Annotating Citations section for how to insert links into the original text using
@@ -74,10 +74,11 @@ citations extracted from the cleaned text.
 
 :code:`clean_text` currently accepts these values as cleaners:
 
-1. :code:`whitespace`: replace all runs of tab and space characters with a single space character
-2. :code:`underscores`: remove two or more underscores, a common error in text extracted from PDFs
-3. :code:`html`: remove non-visible HTML content using the lxml library
-4. Custom function: any function taking a string and returning a string.
+1. :code:`inline_whitespace`: replace all runs of tab and space characters with a single space character
+2. :code:`all_whitespace`: replace all runs of any whitespace character with a single space character
+3. :code:`underscores`: remove two or more underscores, a common error in text extracted from PDFs
+4. :code:`html`: remove non-visible HTML content using the lxml library
+5. Custom function: any function taking a string and returning a string.
 
 
 Annotating Citations
@@ -109,7 +110,7 @@ the original text in as :code:`source_text`:
     from eyecite import get_citations, annotate, clean_text
 
     source_text = '<p>bob lissner v. <i>test   1 U.S.</i> 12,   347-348 (4th Cir. 1982)</p>'
-    plain_text = clean_text(source_text, ['html', 'whitespace'])
+    plain_text = clean_text(source_text, ['html', 'inline_whitespace'])
     citations = get_citations(plain_text)
     linked_text = annotate(plain_text, [[c.span(), "<a>", "</a>"] for c in citations], source_text=source_text)
 

--- a/eyecite/cleaners.py
+++ b/eyecite/cleaners.py
@@ -22,8 +22,8 @@ def html(html_content: str) -> str:
     return " ".join(text)
 
 
-def whitespace(text: str) -> str:
-    """Collapse multiple spaces into one space character."""
+def spaces_and_tabs(text: str) -> str:
+    """Collapse multiple spaces or tabs into one space character."""
     return re.sub(r"[ \t]+", " ", text)
 
 
@@ -35,6 +35,6 @@ def underscores(text: str) -> str:
 
 cleaners_lookup: Dict[str, Callable[[str], str]] = {
     "html": html,
-    "whitespace": whitespace,
+    "spaces_and_tabs": spaces_and_tabs,
     "underscores": underscores,
 }

--- a/eyecite/cleaners.py
+++ b/eyecite/cleaners.py
@@ -27,6 +27,11 @@ def spaces_and_tabs(text: str) -> str:
     return re.sub(r"[ \t]+", " ", text)
 
 
+def all_whitespace(text: str) -> str:
+    """Collapse multiple whitespace characters into one space character."""
+    return re.sub(r"\s+", " ", text)
+
+
 def underscores(text: str) -> str:
     """Remove strings of two or more underscores that are common
     in text extracted from PDFs."""
@@ -36,5 +41,6 @@ def underscores(text: str) -> str:
 cleaners_lookup: Dict[str, Callable[[str], str]] = {
     "html": html,
     "spaces_and_tabs": spaces_and_tabs,
+    "all_whitespace": all_whitespace,
     "underscores": underscores,
 }

--- a/eyecite/cleaners.py
+++ b/eyecite/cleaners.py
@@ -22,7 +22,7 @@ def html(html_content: str) -> str:
     return " ".join(text)
 
 
-def spaces_and_tabs(text: str) -> str:
+def inline_whitespace(text: str) -> str:
     """Collapse multiple spaces or tabs into one space character."""
     return re.sub(r"[ \t]+", " ", text)
 
@@ -40,7 +40,7 @@ def underscores(text: str) -> str:
 
 cleaners_lookup: Dict[str, Callable[[str], str]] = {
     "html": html,
-    "spaces_and_tabs": spaces_and_tabs,
+    "inline_whitespace": inline_whitespace,
     "all_whitespace": all_whitespace,
     "underscores": underscores,
 }

--- a/tests/test_AnnotateTest.py
+++ b/tests/test_AnnotateTest.py
@@ -31,20 +31,20 @@ class AnnotateTest(TestCase):
             (
                 "<body>foo  <i>1   <b>U.S.</b></i>   1 bar</body>",
                 "<body>foo  <i><0>1   <b>U.S.</b></i>   1</0> bar</body>",
-                ["html", "spaces_and_tabs"],
+                ["html", "inline_whitespace"],
             ),
             # whitespace and html -- skip unbalanced tags
             (
                 "foo  <i>1 U.S.</i> 1; 2 <i>U.S.</i> 2",
                 "foo  <i>1 U.S.</i> 1; <1>2 <i>U.S.</i> 2</1>",
-                ["html", "spaces_and_tabs"],
+                ["html", "inline_whitespace"],
                 {"unbalanced_tags": "skip"},
             ),
             # whitespace and html -- wrap unbalanced tags
             (
                 "<i>1 U.S.</i> 1; 2 <i>U.S.</i> 2",
                 "<i><0>1 U.S.</0></i><0> 1</0>; <1>2 <i>U.S.</i> 2</1>",
-                ["html", "spaces_and_tabs"],
+                ["html", "inline_whitespace"],
                 {"unbalanced_tags": "wrap"},
             ),
             # whitespace containing linebreaks

--- a/tests/test_AnnotateTest.py
+++ b/tests/test_AnnotateTest.py
@@ -31,20 +31,20 @@ class AnnotateTest(TestCase):
             (
                 "<body>foo  <i>1   <b>U.S.</b></i>   1 bar</body>",
                 "<body>foo  <i><0>1   <b>U.S.</b></i>   1</0> bar</body>",
-                ["html", "whitespace"],
+                ["html", "spaces_and_tabs"],
             ),
             # whitespace and html -- skip unbalanced tags
             (
                 "foo  <i>1 U.S.</i> 1; 2 <i>U.S.</i> 2",
                 "foo  <i>1 U.S.</i> 1; <1>2 <i>U.S.</i> 2</1>",
-                ["html", "whitespace"],
+                ["html", "spaces_and_tabs"],
                 {"unbalanced_tags": "skip"},
             ),
             # whitespace and html -- wrap unbalanced tags
             (
                 "<i>1 U.S.</i> 1; 2 <i>U.S.</i> 2",
                 "<i><0>1 U.S.</0></i><0> 1</0>; <1>2 <i>U.S.</i> 2</1>",
-                ["html", "whitespace"],
+                ["html", "spaces_and_tabs"],
                 {"unbalanced_tags": "wrap"},
             ),
             # multiple Id. tags

--- a/tests/test_AnnotateTest.py
+++ b/tests/test_AnnotateTest.py
@@ -47,6 +47,8 @@ class AnnotateTest(TestCase):
                 ["html", "spaces_and_tabs"],
                 {"unbalanced_tags": "wrap"},
             ),
+            # whitespace containing linebreaks
+            ("1\nU.S. 1", "<0>1\nU.S. 1</0>", ["all_whitespace"]),
             # multiple Id. tags
             (
                 "1 U.S. 1. Id. 2 U.S. 2. Id.",

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -230,7 +230,7 @@ class FindTest(TestCase):
             # Test italicized Ibid. citation
             ('<p>before asdf. <i>Ibid.</i></p> <p>foo bar lorem</p>',
              [id_citation(2, 'Ibid.', after_tokens=['foo', 'bar', 'lorem'])],
-             {'clean': ['html', 'whitespace']}),
+             {'clean': ['html', 'spaces_and_tabs']}),
             # Test Id. citation
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id., at 123. foo bar',
              [case_citation(3, page='12', plaintiff='foo',
@@ -244,12 +244,12 @@ class FindTest(TestCase):
             ('<p>before asdf. <i>Id.,</i> at 123.</p> <p>foo bar</p>',
              [id_citation(2, 'Id.,', after_tokens=['at', '123.'],
                           has_page=True)],
-             {'clean': ['html', 'whitespace']}),
+             {'clean': ['html', 'spaces_and_tabs']}),
             # Test italicized Id. citation with another HTML tag in the way
             ('<p>before asdf. <i>Id.,</i> at <b>123.</b></p> <p>foo bar</p>',
              [id_citation(2, 'Id.,', after_tokens=['at', '123.'],
                           has_page=True)],
-             {'clean': ['html', 'whitespace']}),
+             {'clean': ['html', 'spaces_and_tabs']}),
             # Test weirder Id. citations (#1344)
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. ¶ 34. foo bar',
              [case_citation(3, page='12', plaintiff='foo',

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -243,7 +243,7 @@ class FindTest(TestCase):
             # Test italicized Ibid. citation
             ('<p>before asdf. <i>Ibid.</i></p> <p>foo bar lorem</p>',
              [id_citation(2, 'Ibid.', after_tokens=['foo', 'bar', 'lorem'])],
-             {'clean': ['html', 'spaces_and_tabs']}),
+             {'clean': ['html', 'inline_whitespace']}),
             # Test Id. citation
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id., at 123. foo bar',
              [case_citation(3, page='12', plaintiff='foo',
@@ -264,12 +264,12 @@ class FindTest(TestCase):
             ('<p>before asdf. <i>Id.,</i> at 123.</p> <p>foo bar</p>',
              [id_citation(2, 'Id.,', after_tokens=['at', '123.'],
                           has_page=True)],
-             {'clean': ['html', 'spaces_and_tabs']}),
+             {'clean': ['html', 'inline_whitespace']}),
             # Test italicized Id. citation with another HTML tag in the way
             ('<p>before asdf. <i>Id.,</i> at <b>123.</b></p> <p>foo bar</p>',
              [id_citation(2, 'Id.,', after_tokens=['at', '123.'],
                           has_page=True)],
-             {'clean': ['html', 'spaces_and_tabs']}),
+             {'clean': ['html', 'inline_whitespace']}),
             # Test weirder Id. citations (#1344)
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. ¶ 34. foo bar',
              [case_citation(3, page='12', plaintiff='foo',

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -99,6 +99,14 @@ class FindTest(TestCase):
             # Basic test
             ('1 U.S. 1',
              [case_citation(0)]),
+            # Basic test with a line break
+            ('1 U.S.\n1',
+             [case_citation(0)],
+             {'clean': ['all_whitespace']}),
+            # Basic test with a line break within a reporter
+            ('1 U.\nS. 1',
+             [case_citation(0, reporter_found='U. S.')],
+             {'clean': ['all_whitespace']}),
             # Basic test of non-case name before citation (should not be found)
             ('lissner test 1 U.S. 1',
              [case_citation(2)]),
@@ -197,6 +205,11 @@ class FindTest(TestCase):
                             antecedent_guess='asdf,')]),
             # Test short form citation at end of document (issue #1171)
             ('before asdf, 1 U. S. end', []),
+            # Test supra citation across line break
+            ('before asdf, supra,\nat 2',
+             [supra_citation(2, "supra,", antecedent_guess='asdf,',
+                             page='2')],
+             {'clean': ['all_whitespace']}),
             # Test short form citation with a page range
             ('before asdf, 1 U. S., at 20-25',
              [case_citation(2, page='20-25', reporter_found='U. S.',
@@ -237,6 +250,13 @@ class FindTest(TestCase):
                             defendant='bar'),
               id_citation(8, 'Id.,', after_tokens=['at', '123.'],
                           has_page=True)]),
+            # Test Id. citation across line break
+            ('foo v. bar 1 U.S. 12, 347-348. asdf. Id.,\nat 123. foo bar',
+             [case_citation(3, page='12', plaintiff='foo',
+                            defendant='bar'),
+              id_citation(8, 'Id.,', after_tokens=['at', '123.'],
+                          has_page=True)],
+             {'clean': ['all_whitespace']}),
             # Test Id. citation at end of text
             ('Id.', [id_citation(0, 'Id.,', after_tokens=[])]),
             ('Id. at 1.', [id_citation(0, 'Id.,', after_tokens=['at', '1.'], has_page=True)]),

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -7,6 +7,7 @@ class UtilsTest(TestCase):
     def test_clean_text(self):
         test_pairs = (
             (["spaces_and_tabs"], "  word \t \n  word  ", " word \n word "),
+            (["all_whitespace"], "  word \t \n  word  ", " word word "),
             (["underscores"], "__word__word_", "wordword_"),
             (["html"], " <style>ignore</style> <i> word </i> ", " word "),
             (

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -6,11 +6,11 @@ from eyecite.utils import clean_text
 class UtilsTest(TestCase):
     def test_clean_text(self):
         test_pairs = (
-            (["whitespace"], "  word \t \n  word  ", " word \n word "),
+            (["spaces_and_tabs"], "  word \t \n  word  ", " word \n word "),
             (["underscores"], "__word__word_", "wordword_"),
             (["html"], " <style>ignore</style> <i> word </i> ", " word "),
             (
-                ["html", "underscores", "whitespace"],
+                ["html", "underscores", "spaces_and_tabs"],
                 " <style>ignore</style> __ <i> word  word </i>",
                 " word word ",
             ),

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -6,12 +6,12 @@ from eyecite.utils import clean_text
 class UtilsTest(TestCase):
     def test_clean_text(self):
         test_pairs = (
-            (["spaces_and_tabs"], "  word \t \n  word  ", " word \n word "),
+            (["inline_whitespace"], "  word \t \n  word  ", " word \n word "),
             (["all_whitespace"], "  word \t \n  word  ", " word word "),
             (["underscores"], "__word__word_", "wordword_"),
             (["html"], " <style>ignore</style> <i> word </i> ", " word "),
             (
-                ["html", "underscores", "spaces_and_tabs"],
+                ["html", "underscores", "inline_whitespace"],
                 " <style>ignore</style> __ <i> word  word </i>",
                 " word word ",
             ),


### PR DESCRIPTION
I believe the tokenizer should support matching citation strings that might break across lines or be internally separated by other whitespace characters.

The full and shortform tests that I added won't pass without the changes in this PR. (The supra and id ones pass fine already -- because we're just matching single tokens for them, no whitespace involved -- but I added tests for them too for good measure.)