### PR TITLE
Use custom regexes from reporters-db

### DIFF
--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -285,6 +285,7 @@ class CitationToken(Token):
     exact_editions: Sequence[Edition] = field(default_factory=tuple)
     variation_editions: Sequence[Edition] = field(default_factory=tuple)
     short: bool = False
+    extra_match_groups: dict = field(default_factory=dict, compare=False)
 
     def __post_init__(self):
         """Make iterables into tuples to make sure we're hashable."""
@@ -301,11 +302,15 @@ class CitationToken(Token):
         "variation_editions" in their extra config. Pass all of that through
         to the constructor."""
         start, end = m.span(0)
+        match_groups = m.groupdict()
         return cls(
             m[0],
             start + offset,
             end + offset,
-            **m.groupdict(),
+            volume=match_groups.pop("volume", ""),
+            reporter=match_groups.pop("reporter", ""),
+            page=match_groups.pop("page", ""),
+            extra_match_groups=match_groups,
             **extra,
         )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -267,7 +267,7 @@ python-versions = "*"
 
 [[package]]
 name = "reporters-db"
-version = "2.0.7"
+version = "3.0.0"
 description = "Database of Court Reporters"
 category = "main"
 optional = false
@@ -331,7 +331,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "1e03cb9763ac2627b88b4877d1d1371ae79457e2d8aae7333a0d94c1b2272a85"
+content-hash = "ff1f0ccc068368cd88e631b1fa8eed0cd0657d5699e624822e1f960f0cf07c6c"
 
 [metadata.files]
 appdirs = [
@@ -461,39 +461,20 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 mccabe = [
@@ -595,8 +576,8 @@ regex = [
     {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
 ]
 reporters-db = [
-    {file = "reporters-db-2.0.7.tar.gz", hash = "sha256:8d1efed6fe52350183e704ab89dbf80b017e16526d95f61bf427687da0e46f81"},
-    {file = "reporters_db-2.0.7-py2.py3-none-any.whl", hash = "sha256:6ab663652e7e36dcab15fb18952b7464d528d02a2093b4634a8adbef97cd7799"},
+    {file = "reporters-db-3.0.0.tar.gz", hash = "sha256:a217611a799f2a8aded48dd63e06108ede0acaabe5c426dc814767a62ace7d4c"},
+    {file = "reporters_db-3.0.0-py2.py3-none-any.whl", hash = "sha256:bf7392857169d4464a4e8ff20b50e84b2b01c6a9aa17c4825d468a210c8eb8ad"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ version = "1.1.0"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-reporters-db = "^2.0.7"
+reporters-db = "^3"
 courts-db = "^0.9.7"
 lxml = "^4.6.2"
 pyahocorasick = ">= 1.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 courts-db==0.9.7
 lxml==4.6.2
 pyahocorasick
-reporters-db==2.0.5
+reporters-db>=3
 six==1.15.0

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -324,6 +324,13 @@ class FindTest(TestCase):
             # past, " U. S. " would match but not " U. S., "
             ('foo 1 U.S., 1 bar',
              [case_citation(0)]),
+            # Test reporter with custom regex
+            ('blah blah Bankr. L. Rep. (CCH) P12,345. blah blah',
+             [case_citation(2, volume='', reporter='Bankr. L. Rep.',
+                            reporter_found='Bankr. L. Rep. (CCH)', page='12,345')]),
+            ('blah blah, 2009 12345 (La.App. 1 Cir. 05/10/10). blah blah',
+             [case_citation(2, volume='2009', reporter='La.App. 1 Cir.',
+                            page='12345')]),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Citation extraction")

--- a/tests/test_TokenizeTest.py
+++ b/tests/test_TokenizeTest.py
@@ -39,5 +39,7 @@ class TokenizerTest(TestCase):
             ("id.", "ibid."),
         }
         extractors = AhocorasickTokenizer().get_extractors(text)
-        extractor_strings = set(tuple(e.strings) for e in extractors)
+        extractor_strings = set(
+            tuple(e.strings) for e in extractors if e.strings
+        )
         self.assertEqual(expected_strings, extractor_strings)


### PR DESCRIPTION
This is a first pass at using the `"regexes"` field from reporters-db to extract non-standard citations. E.g. from the tests:

```
            # Test reporter with custom regex
            ('blah blah Bankr. L. Rep. (CCH) P12,345. blah blah',
             [case_citation(2, volume='', reporter='Bankr. L. Rep.',
                            reporter_found='Bankr. L. Rep. (CCH)', page='P12,345')]),
            ('blah blah, 2009 12345 (La.App. 1 Cir. 05/10/10). blah blah',
             [case_citation(2, volume='2009', reporter='La.App. 1 Cir.',
                            reporter_found='(La.App. 1 Cir.', page='12345')]),
```

As you can see, volume can sometimes now end up as an empty string. Custom regexes can also extract extra data -- in the last test example `cite.token.extra_match_groups == {"date_filed": "05/10/10"}`.

## Limitations on the file format

There's a few limitations of the existing reporters-db format where I had to make arbitrary choices:

**Multiple editions**

In this example, does the regex map to "Foo" or "Foo 2d"? Since this is unknowable, I just skip over reporters with `"regexes"` and multiple editions; currently there aren't any, but there could be as we improve things.

```
"Foo": [
        {
            ...
            "editions": {
                "Foo": {...},
                "Foo 2d": {...},
            },
            ...,
            "regexes": [
                "(?P<reporter>Foox) (?P<volume>\\d+)-(?P<page>\\d+)"
            ],
        }
    ]
```

**Replace or extend?**

When an entry has `"regexes"`, do we _only_ run those or do we also run the standard `"{volume} {reporter},? {page}"` regexes for the edition and variation strings? I chose to only run the regexes, because in the existing entries like `La.App. 1 Cir.` and `Bankr. L. Rep.` it would be wrong (or at least pointless) to run the standard regexes. But what if we do want to keep the existing ones? For example, suppose normal tax court citations were `1 T.C. 1`, but they could also be cited with a variant reporter and extra parens like `1 UNITED STATES TAX COURT REPORTS (1)`:

```
"T.C.": [
        {
            "editions": {
                "T.C.": {...}
            },
            "regexes": [
                "(?P<volume>\\d+) (?P<reporter>UNITED STATES TAX COURT REPORTS?) \((?P<page>\\d+)\)"
            ],
            "variations": {
                "T. C.": "T.C.",
                "T.C. at": "T.C.",
                "T.Ct": "T.C.",
                "T.Ct.": "T.C.",
                "UNITED STATES TAX COURT REPORT": "T.C.",
                "UNITED STATES TAX COURT REPORTS": "T.C."
            }
        }
    ],
```

Here you would want the custom regex to replace some of the standard regexes but not others, and we don't really have a way to express that ... although we could handle it by providing a redundant standard regex, like

```
            "regexes": [
                "(?P<volume>\\d+) (?P<reporter>T.C.|T. C.|T.C. at|...) (?P<page>\\d+)",
                "(?P<volume>\\d+) (?P<reporter>UNITED STATES TAX COURT REPORTS?) \((?P<page>\\d+)\)"
            ],
```

**Volume and page number regexes**

The regexes for `(?P<volume>...)` and `(?P<page>...)` have a lot of variation in reporters-db, and some stuff that looks non-standard or wrong like `[0-9]{1,}` and `((\d){1,3})+`. It's hard to tell what's intentional and what's just different ways to express "normal page number." This made me wonder if it would be useful to have a placeholder when nothing specific is intended about valid values, along the lines of `(?P<page>{PAGE_REGEX})`.

The above three issues made me wonder if it's worth revisiting the way reporters-db includes regexes, maybe adding a new field, but I don't have an immediate proposal for something that elegantly solves everything.