### PR TITLE
Issue 32 expose test factories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,6 +253,16 @@ eyecite comes with a robust test suite of different citation strings that it is 
 
     python3 -m unittest discover -s tests -p 'test_*.py'
 
+If you would like to create mock citation objects to assist you in writing your own local tests, import and use the following functions for convenience:
+
+::
+
+    from eyecite.test_factories import (
+        case_citation,
+        id_citation,
+        nonopinion_citation,
+        supra_citation,
+    )
 
 License
 =======

--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -21,6 +21,7 @@ def case_citation(
     short=False,
     **kwargs,
 ):
+    """Convenience function for creating mock CaseCitation objects."""
     kwargs.setdefault("canonical_reporter", reporter)
     kwargs.setdefault("reporter_found", reporter)
     if reporter == "U.S.":
@@ -46,12 +47,15 @@ def case_citation(
 
 
 def id_citation(index, source_text, **kwargs):
+    """Convenience function for creating mock IdCitation objects."""
     return IdCitation(IdToken(source_text, 0, 99), index, **kwargs)
 
 
 def nonopinion_citation(index, source_text):
+    """Convenience function for creating mock NonopinionCitation objects."""
     return NonopinionCitation(SectionToken(source_text, 0, 99), index)
 
 
 def supra_citation(index, source_text, **kwargs):
+    """Convenience function for creating mock SupraCitation objects."""
     return SupraCitation(SupraToken(source_text, 0, 99), index, **kwargs)

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -4,21 +4,21 @@ from datetime import datetime
 from unittest import TestCase
 
 from eyecite import clean_text, get_citations
+
+# by default tests use a cache for speed
+# call tests with `EYECITE_CACHE_DIR= python ...` to disable cache
+from eyecite.test_factories import (
+    case_citation,
+    id_citation,
+    nonopinion_citation,
+    supra_citation,
+)
 from eyecite.tokenizers import (
     EDITIONS_LOOKUP,
     EXTRACTORS,
     AhocorasickTokenizer,
     HyperscanTokenizer,
     Tokenizer,
-)
-
-# by default tests use a cache for speed
-# call tests with `EYECITE_CACHE_DIR= python ...` to disable cache
-from tests.factories import (
-    case_citation,
-    id_citation,
-    nonopinion_citation,
-    supra_citation,
 )
 
 cache_dir = os.environ.get("EYECITE_CACHE_DIR", ".test_cache") or None

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from tests.factories import case_citation
+from eyecite.test_factories import case_citation
 
 
 class ModelsTest(TestCase):


### PR DESCRIPTION
Re #32, simple change to expose the test factories in the packaged version of eyecite. Impetus is that I'm using them in CL, but I imagine others might want to use them too when writing their own tests.