### PR TITLE
Handle side-by-side tokens with overlapping regexes

### DIFF
--- a/tests/test_TokenizeTest.py
+++ b/tests/test_TokenizeTest.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from eyecite.models import CitationToken, StopWordToken
+from eyecite.models import CitationToken, IdToken, StopWordToken
 from eyecite.tokenizers import (
     EDITIONS_LOOKUP,
     AhocorasickTokenizer,
@@ -25,6 +25,19 @@ class TokenizerTest(TestCase):
         self.assertEqual(
             list(tokenize("Foo bar eats grue, 232 U.S. (2003)")),
             ["Foo", "bar", "eats", "grue,", "232", "U.S.", "(2003)"],
+        )
+
+    def test_overlapping_regexes(self):
+        # Make sure we find both "see" and "id." tokens even though their
+        # full regexes overlap
+        self.assertEqual(
+            list(default_tokenizer.tokenize("see id. at 577.")),
+            [
+                StopWordToken(data="see", start=0, end=3, stop_word="see"),
+                IdToken(data="id.", start=4, end=7),
+                "at",
+                "577.",
+            ],
         )
 
     def test_extractor_filter(self):


### PR DESCRIPTION
This fixes #46. As @mattdahl suggested, that bug is because the full regexes for "see" and "id." overlap (they both capture the space between them, but then ignore it by only grabbing what's in the match group). Unlike the regexes, the tokens generated from each regex have correct start and end offsets and don't overlap, so the core fix was just a one-liner to compare offsets on `extractor.get_token(m)` instead of the offsets of `m.span()` itself.

What made that tricky was that hyperscan works on bytes instead of strings, and dealing with the byte offsets was complicating everything. I realized that I could instead update the byte offsets right after they came out of hyperscan, and make it easier to work with everything downstream. Thus began refactoring.

So this has a bunch of changed lines, but it's hopefully just untangling some things to make any bugs like this easier to fix in the future.