### PR TITLE
Make source_text parameter optional in test factories

### DIFF
--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -46,16 +46,16 @@ def case_citation(
     )
 
 
-def id_citation(index, source_text, **kwargs):
+def id_citation(index, source_text=None, **kwargs):
     """Convenience function for creating mock IdCitation objects."""
     return IdCitation(IdToken(source_text, 0, 99), index, **kwargs)
 
 
-def nonopinion_citation(index, source_text):
+def nonopinion_citation(index, source_text=None):
     """Convenience function for creating mock NonopinionCitation objects."""
     return NonopinionCitation(SectionToken(source_text, 0, 99), index)
 
 
-def supra_citation(index, source_text, **kwargs):
+def supra_citation(index, source_text=None, **kwargs):
     """Convenience function for creating mock SupraCitation objects."""
     return SupraCitation(SupraToken(source_text, 0, 99), index, **kwargs)


### PR DESCRIPTION
I should have included this in my previous PR, but this is just a tweak to make the `source_text` parameter optional in the factory functions. When creating mock objects, it is not necessary that a token's data be anything other than `None` (though the user is welcome to set it to something else if they want). The `case_citation()` function already has `None` as its default; this change just brings the other functions in line.