### PR TITLE
Allow custom annotation formats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,20 @@ regularly formatted documents such as case text published by courts. It may have
 unpredictable results for deliberately-constructed challenging inputs such as citations containing partial HTML
 comments or :code:`<pre>` tags.
 
+Customizing Annotation
+----------------------
+
+If inserting text before and after isn't sufficient, supply a callable under the :code:`annotator` parameter
+that takes :code:`(before, span_text, after)` and returns the annotated text:
+
+::
+
+    def annotator(before, span_text, after):
+        return before + span_text.lower() + after
+    linked_text = annotate(plain_text, [[c.span(), "<a>", "</a>"] for c in citations], annotator=annotator)
+
+    returns:
+    'bob lissner v. test <a>1 u.s. 12</a>, 347-348 (4th Cir. 1982)'
 
 Tokenizers
 ==========

--- a/tests/test_AnnotateTest.py
+++ b/tests/test_AnnotateTest.py
@@ -9,6 +9,9 @@ class AnnotateTest(TestCase):
         def straighten_quotes(text):
             return text.replace("’", "'")
 
+        def lower_annotator(before, text, after):
+            return before + text.lower() + after
+
         test_pairs = (
             # single cite
             ("1 U.S. 1", "<0>1 U.S. 1</0>", []),
@@ -61,6 +64,13 @@ class AnnotateTest(TestCase):
                 "1 Abbott’s Pr.Rep. 1",
                 "<0>1 Abbott’s Pr.Rep. 1</0>",
                 [straighten_quotes],
+            ),
+            # custom annotator
+            (
+                "1 U.S. 1",
+                "<0>1 u.s. 1</0>",
+                [],
+                {"annotator": lower_annotator},
             ),
         )
         for source_text, expected, clean_steps, *annotate_kwargs in test_pairs:


### PR DESCRIPTION
I ran into an edge case for CAP where citations can contain page numbers:

`1 U.S. <a class="page-label" ...>123</a>1`

I have a cleaning step that removes these links and their text for cite extraction, but then annotating doesn't work -- I get `<a href="/us/1/1/">1 U.S. <a class="page-label" ...>123</a>1</a>`, which is bad HTML, and `unbalanced_tags` can't help.

This PR adds an `annotator` argument to `annotate()` so I can pass in a callable with custom handling for this case -- see the edited Readme for an example.

As usual I'd welcome naming suggestions if `annotator` is confusing.