### PR TITLE
Avoid scanning tokens past end of input

### DIFF
--- a/eyecite/find_citations.py
+++ b/eyecite/find_citations.py
@@ -132,7 +132,8 @@ def extract_shortform_citation(
     Shortform 1: Adarand, 515 U.S., at 241
     Shortform 2: 515 U.S., at 241
     """
-    # Get antecedent
+    # Get antecedent -- either previous word, or previous two words if
+    # previous word is a comma
     antecedent_guess = None
     if index > 0:
         antecedent_guess = str(words[index - 1])
@@ -172,16 +173,17 @@ def extract_supra_citation(
     Supra 3: Adarand, supra, somethingelse
     Supra 4: Adrand, supra. somethingelse
     """
-    # Get volume
-    volume = None
-
-    # Get page
+    # Get page, with bounds check to ensure we don't scan past end of words.
+    # Use index + 2 to skip "at".
     page = None
     if index + 2 < len(words):
         page = parse_page(str(words[index + 2]))
 
-    # Get antecedent
+    # Get antecedent -- either previous word, or previous two words if
+    # previous word is a comma. If previous word is a digit, store as
+    # volume and use next previous word as antecedent.
     antecedent_guess = None
+    volume = None
     if index > 0:
         antecedent_guess = str(words[index - 1])
         if antecedent_guess.isdigit():
@@ -234,24 +236,23 @@ def extract_id_citation(
             not isinstance(token, Token) and parse_page(token)
         )
 
-    # Check if the post-id token is indeed a page candidate
-    scan_index = index
+    # Check if the post-id token is indeed a page candidate.
+    # If so, set scan_index to capture all page candidates immediately
+    # following Id. cite.
+    scan_index = index + 1
     has_page = False
-    while scan_index + 1 < len(words) and is_page_candidate(
-        words[scan_index + 1]
-    ):
+    while scan_index < len(words) and is_page_candidate(words[scan_index]):
         scan_index += 1
         has_page = True
 
-    # If it is not, simply set a naive anchor for the end of the scan_index
-    if scan_index == index:
-        has_page = False
-        scan_index = index + 3
+    # If it is not, simply set a naive anchor for the end of the scan_index.
+    if not has_page:
+        scan_index = min(index + 4, len(words))
 
     # Only linkify the after tokens if a page is found
     return IdCitation(
         cast(IdToken, words[index]),
         index,
-        after_tokens=words[index + 1 : scan_index + 1],
+        after_tokens=words[index + 1 : scan_index],
         has_page=has_page,
     )

--- a/eyecite/find_citations.py
+++ b/eyecite/find_citations.py
@@ -132,13 +132,15 @@ def extract_shortform_citation(
     Shortform 1: Adarand, 515 U.S., at 241
     Shortform 2: 515 U.S., at 241
     """
-    # Variables to extact
-    antecedent_guess: str
-
     # Get antecedent
-    antecedent_guess = str(words[index - 1])
-    if antecedent_guess == ",":
-        antecedent_guess = str(words[index - 2]) + ","
+    antecedent_guess = None
+    if index > 0:
+        antecedent_guess = str(words[index - 1])
+        if antecedent_guess == ",":
+            if index > 1:
+                antecedent_guess = str(words[index - 2]) + ","
+            else:
+                antecedent_guess = None
 
     # Get citation
     cite_token = cast(CitationToken, words[index])
@@ -170,26 +172,29 @@ def extract_supra_citation(
     Supra 3: Adarand, supra, somethingelse
     Supra 4: Adrand, supra. somethingelse
     """
-    # Don't check if we are at the beginning of a string
-    if index <= 1:
-        return None
-
     # Get volume
     volume = None
 
     # Get page
-    try:
+    page = None
+    if index + 2 < len(words):
         page = parse_page(str(words[index + 2]))
-    except IndexError:
-        page = None
 
     # Get antecedent
-    antecedent_guess = str(words[index - 1])
-    if antecedent_guess.isdigit():
-        volume = antecedent_guess
-        antecedent_guess = str(words[index - 2])
-    elif antecedent_guess == ",":
-        antecedent_guess = str(words[index - 2]) + ","
+    antecedent_guess = None
+    if index > 0:
+        antecedent_guess = str(words[index - 1])
+        if antecedent_guess.isdigit():
+            volume = antecedent_guess
+            if index > 1:
+                antecedent_guess = str(words[index - 2])
+            else:
+                antecedent_guess = None
+        elif antecedent_guess == ",":
+            if index > 1:
+                antecedent_guess = str(words[index - 2]) + ","
+            else:
+                antecedent_guess = None
 
     # Return SupraCitation
     return SupraCitation(

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -85,7 +85,7 @@ def add_post_citation(citation: CaseCitation, words: Tokens) -> None:
     for start in range(citation.index + 1, min(fwd_sk, len(words))):
         if words[start].startswith("("):
             # Get the year by looking for a token that ends in a paren.
-            for end in range(start, start + FORWARD_SEEK):
+            for end in range(start, min(start + FORWARD_SEEK, len(words))):
                 if ")" in words[end]:
                     # Sometimes the paren gets split from the preceding content
                     if words[end].startswith(")"):
@@ -120,7 +120,7 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
             # Skip it
             continue
         if isinstance(word, StopWordToken):
-            if word.stop_word == "v":
+            if word.stop_word == "v" and index > 0:
                 citation.plaintiff = str(words[index - 1])
             start_index = index + 1
             break

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -255,9 +255,6 @@ class FindTest(TestCase):
               id_citation(8, 'Id.,', after_tokens=['at', '123.'],
                           has_page=True)],
              {'clean': ['all_whitespace']}),
-            # Test Id. citation at end of text
-            ('Id.', [id_citation(0, 'Id.,', after_tokens=[])]),
-            ('Id. at 1.', [id_citation(0, 'Id.,', after_tokens=['at', '1.'], has_page=True)]),
             # Test italicized Id. citation
             ('<p>before asdf. <i>Id.,</i> at 123.</p> <p>foo bar</p>',
              [id_citation(2, 'Id.,', after_tokens=['at', '123.'],
@@ -331,6 +328,21 @@ class FindTest(TestCase):
             ('blah blah, 2009 12345 (La.App. 1 Cir. 05/10/10). blah blah',
              [case_citation(2, volume='2009', reporter='La.App. 1 Cir.',
                             page='12345')]),
+            # Token scanning edge case -- incomplete paren at end of input
+            ('1 U.S. 1 (', [case_citation(0)]),
+            # Token scanning edge case -- missing plaintiff name at start of input
+            ('v. Bar, 1 U.S. 1', [case_citation(0, defendant='Bar,')]),
+            # Token scanning edge case -- short form start of input
+            ('1 U.S., at 1', [case_citation(0, short=True)]),
+            (', 1 U.S., at 1', [case_citation(0, short=True)]),
+            # Token scanning edge case -- supra at start of input
+            ('supra.', [supra_citation(0, "supra.")]),
+            (', supra.', [supra_citation(0, "supra.")]),
+            ('123 supra.', [supra_citation(0, "supra.", volume="123")]),
+            # Token scanning edge case -- Id. at end of input
+            ('Id.', [id_citation(0, 'Id.,', after_tokens=[])]),
+            ('Id. at 1.', [id_citation(0, 'Id.,', after_tokens=['at', '1.'], has_page=True)]),
+            ('Id. foo', [id_citation(0, 'Id.,', after_tokens=['foo'])]),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Citation extraction")


### PR DESCRIPTION
This PR adds bounds checks and tests for a set of partial citation inputs that currently raise IndexError from `get_citations` -- 

```
'123 supra.'
', supra.'
', 1 U.S., at 1'
'1 U.S., at 1'
'v. Bar, 1 U.S. 1'
'1 U.S. 1 ('
```

The one functional change is that `get_citations('supra.')` now returns a `SupraCitation` with no antecedent, where before it would have returned nothing. I think it's less surprising to have `get_citations('supra.')` do the same thing as `get_citations('no cite supra.')` instead of being a special case.