### PR TITLE
fix(annotate): Toggles bisect method by start/end update; fixes #54.

### DIFF
--- a/eyecite/annotate.py
+++ b/eyecite/annotate.py
@@ -1,4 +1,4 @@
-from bisect import bisect_right
+from bisect import bisect_left, bisect_right
 from difflib import SequenceMatcher
 from functools import partial
 from typing import Any, Callable, Iterable, Optional, Tuple
@@ -55,8 +55,8 @@ def annotate(
     for (start, end), before, after in annotations:
         # if we're applying to source_text, update offsets
         if offset_updater:
-            start = offset_updater.update(start)
-            end = offset_updater.update(end)
+            start = offset_updater.update(start, bisect_right)
+            end = offset_updater.update(end, bisect_left)
 
         # handle overlaps
         if start < last_end:
@@ -196,8 +196,8 @@ class SpanUpdater:
             elif operation == "equal":
                 yield "=", a2 - a1
 
-    def update(self, offset):
+    def update(self, offset, bisect):
         """Shift an offset left or right."""
-        index = bisect_right(self.offsets, offset) - 1
+        index = bisect(self.offsets, offset) - 1
         updater = self.updaters[index]
         return updater(offset)

--- a/tests/test_AnnotateTest.py
+++ b/tests/test_AnnotateTest.py
@@ -51,6 +51,13 @@ class AnnotateTest(TestCase):
                 ["html", "inline_whitespace"],
                 {"unbalanced_tags": "wrap"},
             ),
+            # tighly-wrapped html -- skip unbalanced tags (issue #54)
+            (
+                "foo <i>Ibid.</i> bar",
+                "foo <i><0>Ibid.</0></i> bar",
+                ["html", "inline_whitespace"],
+                {"unbalanced_tags": "skip"},
+            ),
             # whitespace containing linebreaks
             ("1\nU.S. 1", "<0>1\nU.S. 1</0>", ["all_whitespace"]),
             # multiple Id. tags


### PR DESCRIPTION
This PR is a simple fix to address the problem I identified in #54.

Before, we would always use `bisect_right()` to determine the index of the updater function to use when calculating the new offsets for an annotation. This makes sense when we are updating the _start_ offset for a string, because we want to use the updater whose position is `bisect_right() - 1` and `bisect_right()` returns the index that is one to the right of the offset index. However, this causes a kind of off-by-one error with the _end_ offset of a string, since we now want the index in the other (leftward) direction instead. Hence, I think we need to use `bisect_left()` for the end offsets, which returns the index that is one to the left of the offset index.

Apologies if this is confusing, it's difficult for me to explain the intuition. See more here: https://docs.python.org/3/library/bisect.html

@jcushman you know this code better than me, does this make sense to you? Do you think this introduces problems elsewhere?