### PR TITLE
Update year parsing

### DIFF
--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -1,4 +1,5 @@
 import re
+from datetime import date
 from typing import List, Optional, Union
 
 from courts_db import courts
@@ -48,20 +49,20 @@ def get_court_by_paren(
     return court_code
 
 
+# Highest valid year is this year + 1 because courts in December sometimes
+# cite a case to be published in January.
+_highest_valid_year = date.today().year + 1
+
+
 def get_year(token: TokenOrStr) -> Optional[int]:
-    """Given a string token, look for a valid 4-digit number at the start and
-    return its value.
-    """
+    """Given a string token, look for a year within a reasonable range."""
     word = strip_punct(str(token))
-    if not word.isdigit():
-        # Sometimes funny stuff happens?
-        word = re.sub(r"(\d{4}).*", r"\1", word)
-        if not word.isdigit():
-            return None
-    if len(word) != 4:
+    try:
+        year = int(word)
+    except ValueError:
         return None
-    year = int(word)
-    if year < 1754:  # Earliest case in the database
+
+    if year < 1600 or year > _highest_valid_year:
         return None
     return year
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -117,6 +117,9 @@ class FindTest(TestCase):
             ('lissner v. test 1 U.S. 1 (1982)',
              [case_citation(3, plaintiff='lissner', defendant='test',
                             year=1982)]),
+            # Don't choke on misformatted year
+            ('lissner v. test 1 U.S. 1 (198⁴)',
+             [case_citation(3, plaintiff='lissner', defendant='test')]),
             # Test with different reporter than all of above.
             ('bob lissner v. test 1 F.2d 1 (1982)',
              [case_citation(4, reporter='F.2d', canonical_reporter='F.',


### PR DESCRIPTION
This updates year parsing to fix a ValueError CAP ran into on the input "123 U.S. 456 (196⁴)", and makes some other changes along the way.

* No longer use `isdigit`, which I just learned returns True for unicode digit characters, just attempt int() conversion and catch ValueError.
* Don't accept all strings that start with four digit characters, so we don't parse `"2000000"` as `2000`. If there are things we're trying to handle with `r"(\d{4}).*"` let's use a tighter regex.
* Bump the minimum date back to 1600, since CAP goes back to 1658.
* Add a maximum date of the current year.