### PR TITLE
Tighten page number matching; extend pin cite matching; extract parentheticals

### DIFF
--- a/eyecite/find_citations.py
+++ b/eyecite/find_citations.py
@@ -140,7 +140,7 @@ def extract_shortform_citation(
         forward=False,
     )
     if m:
-        antecedent_guess = m[1].strip()
+        antecedent_guess = m["antecedent"].strip()
 
     # Get citation
     cite_token = cast(CitationToken, words[index])
@@ -187,13 +187,8 @@ def extract_supra_citation(
         forward=False,
     )
     if m:
-        if m[1]:
-            antecedent_guess = m[1].strip()
-            volume = m[2].strip()
-        elif m[3]:
-            volume = m[3].strip()
-        else:
-            antecedent_guess = m[4].strip()
+        antecedent_guess = m["antecedent"]
+        volume = m["volume"]
 
     # Return SupraCitation
     return SupraCitation(

--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -28,6 +28,8 @@ def case_citation(
         kwargs.setdefault("court", "scotus")
     if not source_text:
         source_text = f"{volume} {reporter} {page}"
+    if short:
+        kwargs.setdefault("pin_cite", page)
     edition = EDITIONS_LOOKUP[reporter][0]
     token = CitationToken(
         source_text,

--- a/poetry.lock
+++ b/poetry.lock
@@ -77,6 +77,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "exrex"
+version = "0.10.5"
+description = "Irregular methods for regular expressions"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "flake8"
 version = "3.9.0"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -275,7 +283,7 @@ python-versions = "*"
 
 [[package]]
 name = "reporters-db"
-version = "3.0.0"
+version = "3.0.1"
 description = "Database of Court Reporters"
 category = "main"
 optional = false
@@ -283,6 +291,14 @@ python-versions = "*"
 
 [package.dependencies]
 six = "*"
+
+[[package]]
+name = "roman"
+version = "3.3"
+description = "Integer to Roman numerals converter"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [[package]]
 name = "six"
@@ -339,7 +355,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0d90a18c7769f3102c703efe2a8cd943e85230fa54b1a09bc72244e4475a9754"
+content-hash = "34e80e2a46cc8fcda30d9cd07ba733c2922088fa10f92137450a8f9167a8b2a9"
 
 [metadata.files]
 appdirs = [
@@ -367,6 +383,9 @@ courts-db = [
 ]
 diff-match-patch-python = [
     {file = "diff_match_patch_python-1.0.2.tar.gz", hash = "sha256:5a833417344def272ad7dee7c5d455cf3aaf4fb0ffb58029d73e29512dd3ed48"},
+]
+exrex = [
+    {file = "exrex-0.10.5.tar.gz", hash = "sha256:3fb8b18fd9832eaff8b13dc042a4f63b13c5d684ee069f70a23ddfc6bcb708f3"},
 ]
 flake8 = [
     {file = "flake8-3.9.0-py2.py3-none-any.whl", hash = "sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff"},
@@ -584,8 +603,12 @@ regex = [
     {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
 ]
 reporters-db = [
-    {file = "reporters-db-3.0.0.tar.gz", hash = "sha256:a217611a799f2a8aded48dd63e06108ede0acaabe5c426dc814767a62ace7d4c"},
-    {file = "reporters_db-3.0.0-py2.py3-none-any.whl", hash = "sha256:bf7392857169d4464a4e8ff20b50e84b2b01c6a9aa17c4825d468a210c8eb8ad"},
+    {file = "reporters-db-3.0.1.tar.gz", hash = "sha256:ef90064c9e7782a4b8c5b00ca1d9d0d660d316736a6e9e78f81bdfee678b0b40"},
+    {file = "reporters_db-3.0.1-py2.py3-none-any.whl", hash = "sha256:e5a84e79e168babef457a85018875dc1f3528ba26a0e86078b520427089da076"},
+]
+roman = [
+    {file = "roman-3.3-py2.py3-none-any.whl", hash = "sha256:c2a1f14ab47373aecc141edbcdd66595949c9d0ed932fe76bd547df1b55f7278"},
+    {file = "roman-3.3.tar.gz", hash = "sha256:2c46ac8db827d34e4fa9ccc0577e7f0b0d84f16ffe112351bd4f1ec2eb12d73f"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -275,9 +275,9 @@ pylint = "*"
 
 [[package]]
 name = "regex"
-version = "2020.11.13"
+version = "2021.4.4"
 description = "Alternative regular expression module, to replace re."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -355,7 +355,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "34e80e2a46cc8fcda30d9cd07ba733c2922088fa10f92137450a8f9167a8b2a9"
+content-hash = "922b4c963f445181457a543dfe726ed4524c0db19c3715ac21d4cf36040e1e82"
 
 [metadata.files]
 appdirs = [
@@ -560,47 +560,47 @@ pylint-json2html = [
     {file = "pylint_json2html-0.3.0-py3-none-any.whl", hash = "sha256:b646a6b1e190e730967219cd4ae9bb8217e218cd8f34ecc7f15d0803cb13f9d8"},
 ]
 regex = [
-    {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6e4b08c6f8daca7d8f07c8d24e4331ae7953333dbd09c648ed6ebd24db5a10ee"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bba349276b126947b014e50ab3316c027cac1495992f10e5682dc677b3dfa0c5"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:56e01daca75eae420bce184edd8bb341c8eebb19dd3bce7266332258f9fb9dd7"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:6a8ce43923c518c24a2579fda49f093f1397dad5d18346211e46f134fc624e31"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab79fcb02b930de09c76d024d279686ec5d532eb814fd0ed1e0051eb8bd2daa"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:9801c4c1d9ae6a70aeb2128e5b4b68c45d4f0af0d1535500884d644fa9b768c6"},
-    {file = "regex-2020.11.13-cp36-cp36m-win32.whl", hash = "sha256:49cae022fa13f09be91b2c880e58e14b6da5d10639ed45ca69b85faf039f7a4e"},
-    {file = "regex-2020.11.13-cp36-cp36m-win_amd64.whl", hash = "sha256:749078d1eb89484db5f34b4012092ad14b327944ee7f1c4f74d6279a6e4d1884"},
-    {file = "regex-2020.11.13-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b2f4007bff007c96a173e24dcda236e5e83bde4358a557f9ccf5e014439eae4b"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:38c8fd190db64f513fe4e1baa59fed086ae71fa45083b6936b52d34df8f86a88"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5862975b45d451b6db51c2e654990c1820523a5b07100fc6903e9c86575202a0"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:262c6825b309e6485ec2493ffc7e62a13cf13fb2a8b6d212f72bd53ad34118f1"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bafb01b4688833e099d79e7efd23f99172f501a15c44f21ea2118681473fdba0"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e32f5f3d1b1c663af7f9c4c1e72e6ffe9a78c03a31e149259f531e0fed826512"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3bddc701bdd1efa0d5264d2649588cbfda549b2899dc8d50417e47a82e1387ba"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:02951b7dacb123d8ea6da44fe45ddd084aa6777d4b2454fa0da61d569c6fa538"},
-    {file = "regex-2020.11.13-cp37-cp37m-win32.whl", hash = "sha256:0d08e71e70c0237883d0bef12cad5145b84c3705e9c6a588b2a9c7080e5af2a4"},
-    {file = "regex-2020.11.13-cp37-cp37m-win_amd64.whl", hash = "sha256:1fa7ee9c2a0e30405e21031d07d7ba8617bc590d391adfc2b7f1e8b99f46f444"},
-    {file = "regex-2020.11.13-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:baf378ba6151f6e272824b86a774326f692bc2ef4cc5ce8d5bc76e38c813a55f"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e3faaf10a0d1e8e23a9b51d1900b72e1635c2d5b0e1bea1c18022486a8e2e52d"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2a11a3e90bd9901d70a5b31d7dd85114755a581a5da3fc996abfefa48aee78af"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1ebb090a426db66dd80df8ca85adc4abfcbad8a7c2e9a5ec7513ede522e0a8f"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b2b1a5ddae3677d89b686e5c625fc5547c6e492bd755b520de5332773a8af06b"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2c99e97d388cd0a8d30f7c514d67887d8021541b875baf09791a3baad48bb4f8"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:c084582d4215593f2f1d28b65d2a2f3aceff8342aa85afd7be23a9cad74a0de5"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:a3d748383762e56337c39ab35c6ed4deb88df5326f97a38946ddd19028ecce6b"},
-    {file = "regex-2020.11.13-cp38-cp38-win32.whl", hash = "sha256:7913bd25f4ab274ba37bc97ad0e21c31004224ccb02765ad984eef43e04acc6c"},
-    {file = "regex-2020.11.13-cp38-cp38-win_amd64.whl", hash = "sha256:6c54ce4b5d61a7129bad5c5dc279e222afd00e721bf92f9ef09e4fae28755683"},
-    {file = "regex-2020.11.13-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1862a9d9194fae76a7aaf0150d5f2a8ec1da89e8b55890b1786b8f88a0f619dc"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4902e6aa086cbb224241adbc2f06235927d5cdacffb2425c73e6570e8d862364"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7a25fcbeae08f96a754b45bdc050e1fb94b95cab046bf56b016c25e9ab127b3e"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:d2d8ce12b7c12c87e41123997ebaf1a5767a5be3ec545f64675388970f415e2e"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f7d29a6fc4760300f86ae329e3b6ca28ea9c20823df123a2ea8693e967b29917"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:717881211f46de3ab130b58ec0908267961fadc06e44f974466d1887f865bd5b"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3128e30d83f2e70b0bed9b2a34e92707d0877e460b402faca908c6667092ada9"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8f6a2229e8ad946e36815f2a03386bb8353d4bde368fdf8ca5f0cb97264d3b5c"},
-    {file = "regex-2020.11.13-cp39-cp39-win32.whl", hash = "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"},
-    {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
-    {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
+    {file = "regex-2021.4.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7"},
+    {file = "regex-2021.4.4-cp36-cp36m-win32.whl", hash = "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29"},
+    {file = "regex-2021.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79"},
+    {file = "regex-2021.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439"},
+    {file = "regex-2021.4.4-cp37-cp37m-win32.whl", hash = "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d"},
+    {file = "regex-2021.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3"},
+    {file = "regex-2021.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87"},
+    {file = "regex-2021.4.4-cp38-cp38-win32.whl", hash = "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac"},
+    {file = "regex-2021.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2"},
+    {file = "regex-2021.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"},
+    {file = "regex-2021.4.4-cp39-cp39-win32.whl", hash = "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6"},
+    {file = "regex-2021.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07"},
+    {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
 ]
 reporters-db = [
     {file = "reporters-db-3.0.1.tar.gz", hash = "sha256:ef90064c9e7782a4b8c5b00ca1d9d0d660d316736a6e9e78f81bdfee678b0b40"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = ["eyecite/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-reporters-db = "^3"
+reporters-db = "^3.0.1"
 courts-db = "^0.9.7"
 lxml = "^4.6.3"
 pyahocorasick = ">= 1.2"
@@ -44,6 +44,8 @@ pylint = "^2.7.2"
 wheel = "^0.35.1"
 pylint-json2html = "^0.3.0"
 hyperscan = ">= 0.1.5"
+exrex = "^0.10.5"
+roman = "^3.3"
 
 [tool.black]
 include = '''.*\.pyi?$'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ courts-db = "^0.9.7"
 lxml = "^4.6.3"
 pyahocorasick = ">= 1.2"
 diff_match_patch_python = "^1.0.2"
+regex = ">=2020.1.8"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"

--- a/tests/test_AnnotateTest.py
+++ b/tests/test_AnnotateTest.py
@@ -22,13 +22,13 @@ class AnnotateTest(TestCase):
             # Id. cite
             (
                 "1 U.S. 1. Foo. Id. Bar. Id. at 2.",
-                "<0>1 U.S. 1</0>. Foo. <1>Id.</1> Bar. <2>Id. at 2.</2>",
+                "<0>1 U.S. 1</0>. Foo. <1>Id.</1> Bar. <2>Id. at 2</2>.",
                 [],
             ),
             # Supra cite
             (
                 "1 U.S. 1. Foo v. Bar, supra at 2.",
-                "<0>1 U.S. 1</0>. Foo v. Bar, <1>supra</1> at 2.",
+                "<0>1 U.S. 1</0>. Foo v. Bar, <1>supra at 2</1>.",
                 [],
             ),
             # whitespace and html -- no unbalanced tag check

--- a/tests/test_TokenizeTest.py
+++ b/tests/test_TokenizeTest.py
@@ -19,25 +19,65 @@ class TokenizerTest(TestCase):
         see_token = StopWordToken("See", 0, 3, "see")
         v_token = StopWordToken("v.", 8, 10, "v")
         self.assertEqual(
-            list(tokenize("See Roe v. Wade, 410 U. S. 113 (1973)")),
-            [see_token, "Roe", v_token, "Wade,", us_citation, "(1973)"],
+            tokenize("See Roe v. Wade, 410 U. S. 113 (1973)"),
+            (
+                [
+                    see_token,
+                    " ",
+                    "Roe",
+                    " ",
+                    v_token,
+                    " ",
+                    "Wade,",
+                    " ",
+                    us_citation,
+                    " ",
+                    "(1973)",
+                ],
+                [(0, see_token), (4, v_token), (8, us_citation)],
+            ),
         )
         self.assertEqual(
-            list(tokenize("Foo bar eats grue, 232 U.S. (2003)")),
-            ["Foo", "bar", "eats", "grue,", "232", "U.S.", "(2003)"],
+            tokenize("Foo bar eats grue, 232 U.S. (2003)"),
+            (
+                [
+                    "Foo",
+                    " ",
+                    "bar",
+                    " ",
+                    "eats",
+                    " ",
+                    "grue,",
+                    " ",
+                    "232",
+                    " ",
+                    "U.S.",
+                    " ",
+                    "(2003)",
+                ],
+                [],
+            ),
         )
 
     def test_overlapping_regexes(self):
         # Make sure we find both "see" and "id." tokens even though their
         # full regexes overlap
+        stop_token = StopWordToken(data="see", start=0, end=3, stop_word="see")
+        id_token = IdToken(data="id.", start=4, end=7)
         self.assertEqual(
-            list(default_tokenizer.tokenize("see id. at 577.")),
-            [
-                StopWordToken(data="see", start=0, end=3, stop_word="see"),
-                IdToken(data="id.", start=4, end=7),
-                "at",
-                "577.",
-            ],
+            default_tokenizer.tokenize("see id. at 577."),
+            (
+                [
+                    stop_token,
+                    " ",
+                    id_token,
+                    " ",
+                    "at",
+                    " ",
+                    "577.",
+                ],
+                [(0, stop_token), (2, id_token)],
+            ),
         )
 
     def test_extractor_filter(self):

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
 
-from eyecite.utils import clean_text
+import exrex
+import roman
+
+from eyecite.utils import ROMAN_NUMERAL_REGEX, clean_text
 
 
 class UtilsTest(TestCase):
@@ -30,3 +33,18 @@ class UtilsTest(TestCase):
     def test_clean_text_invalid(self):
         with self.assertRaises(ValueError):
             clean_text("foo", ["invalid"])
+
+    def test_roman_numeral_regex(self):
+        """Make sure ROMAN_NUMERAL_REGEX matches all numbers between 1-199
+        except 5, 50, 100."""
+        expected = (
+            list(range(1, 5))
+            + list(range(6, 50))
+            + list(range(51, 100))
+            + list(range(101, 200))
+        )
+        actual = sorted(
+            roman.fromRoman(n.upper())
+            for n in exrex.generate(ROMAN_NUMERAL_REGEX)
+        )
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
As usual I started pulling a string and ended up reknitting the sweater, so this is way too big to review -- apologies yet again. :)

This PR grows out of #56, regarding excess roman numeral page matches, and #52, regarding tightening full-cite matches to not match patterns like "A1 P 1A" as "1 P. 1". Along the way to getting those working I ended up building a useful helper function for running regular expressions against the extracted tokens, and using it to more precisely extract pin cites, and I threw in a bonus feature to extract citation parentheticals as well.

**TL;DR -- API changes:**

Here's what I know of that visibly changes with this PR when calling `get_citations()`:

* Attribute changes:
  * All citations gain a `pin_cite` attribute, which includes the entire pin cite ("at 1, 2-3 & n. 7").
  * `IdCitation` loses the `has_page` and `after_tokens` attributes.
  * `SupraCitation` loses the `page` attribute.
  * (`ShortCaseCitation` keeps its `page` attribute, so "1 U.S. at 4-5" ends up with `page="4", pin_cite="4-5"`. I don't know if this is correct or if page should be `None`, but it feels reasonable since we at least know that short cites ought to start with a page number.)
  * `FullCaseCitation` gains a `parenthetical` attribute.
  * `antecedent` no longer includes the trailing comma.
  * The highlighted `span()` range for `IdCitation`, `SupraCitation`, and `ShortCaseCitation` now includes the pin cite.
* Matching restrictions:
  * Cites no longer match with trailing or following alphanumeric characters, like "A1 P 1" or "1 P 1A".
  * Metadata extraction joins cite extraction in no longer extending across paragraph breaks, so "Id.\n2" won't be treated as "Id. at 2".

**Narrative, for code review:**

Here's how all of this ended up in one bundle ...

* First let's distinguish between page numbers and pin cites: a page number is part of the official citation of a case, like "1 U.S. 1". A pin cite is a string of one or multiple tokens giving extra metadata about where within a document the citation refers to, like "1 U.S. 1, **4-5**", or "1 U.S., **at 7-8 & n. 3**", or "Foo, supra, **at ¶10-11**", or "Id. **at 1:10-2:5**". This whole massive PR relates to detangling those two concepts so we can more precisely identify actual case cites. :)
  * Query: does "at " belong in the `pin_cite` attribute for those examples? I could go either way. It's currently in.
* So first we want to tighten the `PAGE_NUMBER_REGEX` for matching actual page numbers. Almost all of that existing regex  has moved to reporter-specific regexes in reporters-db and can be deleted. The one exception is roman numerals, which we do want to match since there are frequent-enough citations to front matter. But per #56 we only want to match lower case numerals below 200 other than `v`, `l`, and `c` to avoid false positives, so let's add a fancy regex to do that and a test to make sure it's correct.
* Per #52, we'll also tighten the full cite token extractor to require non-alphanumeric characters to the left and right of the citation itself.
  * This means we no longer need `remove_address_citations`, so remove that.
* Now that we've tightened cite extraction this way, our tests expecting "1 U. S., at 20-25" to come in with the page "20-25" start to fail! That test _should_ fail -- it's not a page, it's a pin cite for a case named "1 U.S. 15" or something. So we add a big `PIN_CITE_REGEX` that knows how to match all of those pin cite formats. And we need some way to run it, so we'll add a function `match_on_tokens` that is able to scan through `words = [ShortCite("1 U.S., at 20"), "-", "25"]` and build up a string like "20-25" to apply the pin-cite-matching regex to. Once we're able to extract data with regexes forwards and backwards from a given token, we can use that to attach a new `pin_cite` metadata attribute to short cites and supra cites and id. cites.
  * This new regex scanning approach with `match_on_tokens` allows our pin cite matching to be much more robust! Where before we were matching just "Id. at <digit>" or "Id. <digit>", we'll now get stuff like "Id. at 3, 4-5 & n. 7".
* Uh oh, another test failed -- when we later insert annotations we want to link to "Id. at 2" instead of just "Id.", so cite objects need to keep track of where they came from. `IdCitation` was doing that as a special case with the `has_page` and `after_tokens` attributes, but we're not inspecting tokens that way anymore, so let's add `span_start` and `span_end` attributes to all citations to let us override the highlighted text if need be, and use that to extend the highlight to include the pin cite for `IdCitation`, `SupraCitation`, and ShortCitation`.
  * For character-level positioning like this to work, we have to start keeping track of spaces between words. Let's update `Tokenizer` to use `split(" ")` and include the spaces in the emitted tokens with a new `append_text()` method, rather than using `split()` and throwing out all whitespace.
  * For _this_ to work, we have to start tracking paragraph breaks separately, so add a `ParagraphToken` to extract newlines. This turns out to be an accuracy win, because it means we won't interpret "Id.\n2" as "Id. at 2" like we used to. (Remember this is consistent with the existing rule that callers are required to replace newlines with spaces if they don't know where the real paragraph breaks are in their document.)
* Now that we have `match_on_tokens` working, we can use it in some other places!
  * We can do a better job of extracting pin cites and other metadata for full citations like "1 U.S. 1, 4-5, 2 S. Ct. 2, 6-7 (4th Cir. 2012) (overruling foo)". Let's use `match_on_tokens` in `add_post_citation()` to handle that. Now if we're annotating "1 U.S. 1", we'll get "4-5" as `pin_cite` rather than as part of `extra`, and with one more line of the regex we'll pull in "overruling foo" as the `parenthetical` as well.
  * Let's use `match_on_tokens` to extract the antecedent case name for `ShortCite` and `SupraCite`. This currently works the same as it did before, but it will make it easier to use a more flexible pattern in the future.
  * This means the one thing we're _not_ currently using a regex for is `add_defendant()` -- that one's still scanning token by token until it hits a stop word. I'm not sure if that wants to stay that way, but I left it for now because I don't have a strong idea of how to improve case name detection yet, and it's fine to use both strategies for now.
* Getting the new whitespace handling to work took some profiling, in the process of which I noticed that `get_citations()` was spending a lot of time skipping over string tokens. For efficiency let's update `tokenize()` to return separate lists of all tokens and just non-string tokens.