### PR TITLE
Improve parenthetical functionality and resolve silent test failures

### DIFF
--- a/eyecite/find_citations.py
+++ b/eyecite/find_citations.py
@@ -156,7 +156,7 @@ def extract_shortform_citation(
 
     # Get pin_cite
     cite_token = cast(CitationToken, words[index])
-    pin_cite, span_end = extract_pin_cite(
+    pin_cite, span_end, parenthetical = extract_pin_cite(
         words, index, prefix=cite_token.groups["page"]
     )
 
@@ -170,6 +170,7 @@ def extract_shortform_citation(
         metadata={
             "antecedent_guess": antecedent_guess,
             "pin_cite": pin_cite,
+            "parenthetical": parenthetical,
         },
     )
 
@@ -192,7 +193,7 @@ def extract_supra_citation(
     Supra 3: Adarand, supra, somethingelse
     Supra 4: Adrand, supra. somethingelse
     """
-    pin_cite, span_end = extract_pin_cite(words, index)
+    pin_cite, span_end, parenthetical = extract_pin_cite(words, index)
     antecedent_guess = None
     volume = None
     m = match_on_tokens(
@@ -227,7 +228,7 @@ def extract_id_citation(
     immediately succeeding tokens to construct and return an IdCitation
     object.
     """
-    pin_cite, span_end = extract_pin_cite(words, index)
+    pin_cite, span_end, parenthetical = extract_pin_cite(words, index)
     return IdCitation(
         cast(IdToken, words[index]),
         index,

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -121,7 +121,7 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
     if start_index:
         citation.metadata.defendant = "".join(
             str(w) for w in words[start_index : citation.index]
-        ).strip()
+        ).strip(", ")
 
 
 def add_law_metadata(citation: FullLawCitation, words: Tokens) -> None:

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -147,7 +147,7 @@ PIN_CITE_REGEX = rf"""
         # start of next citation
         (?=
             [,.;)\]\\]|  # ending punctuation
-            \ [(\[]|   # space and start of parens
+            \ ?[(\[]|   # space and start of parens
             $          # end of text
         )
     )

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -90,8 +90,9 @@ PARENTHETICAL_REGEX = r"""
     (?:
         # optional space, opening paren
         \ ?\(
-        # capture non-closing-paren characters
-        (?P<parenthetical>[^)]+)
+            # capture until last end paren, we'll trim off extra afterwards
+            (?P<parenthetical>.*)
+           \)
     )?
 """
 
@@ -201,7 +202,7 @@ SUPRA_ANTECEDENT_REGEX = r"""
 """
 
 
-# Post citation regex:
+# Post full citation regex:
 # Capture metadata after a full cite. For example given the citation "1 U.S. 1"
 # with the following text:
 #   1 U.S. 1, 4-5, 2 S. Ct. 2, 6-7 (4th Cir. 2012) (overruling foo)
@@ -211,7 +212,7 @@ SUPRA_ANTECEDENT_REGEX = r"""
 #   court = 4th Cir.
 #   year = 2012
 #   parenthetical = overruling foo
-POST_CITATION_REGEX = rf"""
+POST_FULL_CITATION_REGEX = rf"""
     (?:  # handle a full cite with a valid year paren:
         # content before year paren:
         (?:
@@ -233,6 +234,22 @@ POST_CITATION_REGEX = rf"""
         {PIN_CITE_REGEX}
     )
 """
+
+
+# Post short-form citation regex:
+# Capture pin cite and parenthetical after a short, id, or supra citation.
+# For example, given the citation 'asdf, 1 U.S., at 3 (overruling xyz)',
+# this will capture:
+#   pin_cite = 3
+#   parenthetical = overruling xyz
+POST_SHORT_CITATION_REGEX = rf"""
+    # optional pin cite
+    {PIN_CITE_REGEX}
+    \ ?
+    # optional parenthetical comment:
+    {PARENTHETICAL_REGEX}
+"""
+
 
 # Post law citation regex:
 # statutory and regulatory cites may have publishers and dates after them, like

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -38,13 +38,16 @@ class FindTest(TestCase):
     def run_test_pairs(self, test_pairs, message, tokenizers=None):
         def get_comparison_attrs(cite):
             out = {
-                "index": cite.index,
+                # Indexes are all incorrect/broken at the moment, commenting this
+                # until fixed so that other functionality can be verified by CI.
+                # "index": cite.index,
                 "groups": cite.groups,
                 "metadata": cite.metadata,
             }
             if isinstance(cite, ResourceCitation):
                 out["year"] = cite.year
                 out["corrected_reporter"] = cite.corrected_reporter()
+            return out
 
         if tokenizers is None:
             tokenizers = tested_tokenizers

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -201,25 +201,30 @@ class FindTest(TestCase):
             # Test first kind of short form citation (meaningless antecedent)
             ('before asdf 1 U. S., at 2',
              [case_citation(2, page='2', reporter_found='U. S.', short=True,
-                            metadata={'antecedent_guess': 'asdf'})]),
+                            metadata={'antecedent_guess': 'asdf',
+                                      'court': 'scotus'})]),
             # Test second kind of short form citation (meaningful antecedent)
             ('before asdf, 1 U. S., at 2',
              [case_citation(2, page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
-                            metadata={'antecedent_guess': 'asdf'})]),
+                            metadata={'antecedent_guess': 'asdf',
+                                      'court': 'scotus'})]),
             # Test short form citation with preceding ASCII quotation
             ('before asdf,” 1 U. S., at 2',
              [case_citation(2, page='2', reporter_found='U. S.',
-                            short=True)]),
+                            short=True,
+                            metadata={'court': 'scotus'})]),
             # Test short form citation when case name looks like a reporter
             ('before Johnson, 1 U. S., at 2',
              [case_citation(2, page='2', reporter_found='U. S.', short=True,
-                            metadata={'antecedent_guess': 'Johnson'})]),
+                            metadata={'antecedent_guess': 'Johnson',
+                                      'court': 'scotus'})]),
             # Test short form citation with no comma after reporter
             ('before asdf, 1 U. S. at 2',
              [case_citation(2, page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
-                            metadata={'antecedent_guess': 'asdf'})]),
+                            metadata={'antecedent_guess': 'asdf',
+                                      'court': 'scotus'})]),
             # Test short form citation at end of document (issue #1171)
             ('before asdf, 1 U. S. end', []),
             # Test supra citation across line break
@@ -232,12 +237,14 @@ class FindTest(TestCase):
             ('before asdf, 1 U. S., at 20-25',
              [case_citation(2, page='20', reporter_found='U. S.', short=True,
                             metadata={'pin_cite': '20-25',
-                                      'antecedent_guess': 'asdf'})]),
+                                      'antecedent_guess': 'asdf',
+                                      'court': 'scotus'})]),
             # Test short form citation with a page range with weird suffix
             ('before asdf, 1 U. S., at 20-25\\& n. 4',
              [case_citation(2, page='20', reporter_found='U. S.', short=True,
                             metadata={'pin_cite': '20-25',
-                                      'antecedent_guess': 'asdf'})]),
+                                      'antecedent_guess': 'asdf',
+                                      'court': 'scotus'})]),
             # Test first kind of supra citation (standard kind)
             ('before asdf, supra, at 2',
              [supra_citation(2, "supra,",
@@ -367,8 +374,10 @@ class FindTest(TestCase):
             # Token scanning edge case -- missing plaintiff name at start of input
             ('v. Bar, 1 U.S. 1', [case_citation(0, metadata={'defendant': 'Bar'})]),
             # Token scanning edge case -- short form start of input
-            ('1 U.S., at 1', [case_citation(0, short=True)]),
-            (', 1 U.S., at 1', [case_citation(0, short=True)]),
+            ('1 U.S., at 1', [case_citation(0, short=True,
+                                            metadata={'court': 'scotus'})]),
+            (', 1 U.S., at 1', [case_citation(0, short=True,
+                                              metadata={'court': 'scotus'})]),
             # Token scanning edge case -- supra at start of input
             ('supra.', [supra_citation(0, "supra.")]),
             (', supra.', [supra_citation(0, "supra.")]),

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -123,6 +123,11 @@ class FindTest(TestCase):
              [case_citation(4, reporter='F.2d', year=1982,
                             metadata={'plaintiff': 'lissner',
                                       'defendant': 'test'})]),
+            # Test with comma after defendant's name
+            ('lissner v. test, 1 U.S. 1 (1982)',
+             [case_citation(3, metadata={'plaintiff': 'lissner',
+                                         'defendant': 'test'},
+                            year=1982)]),
             # Test with court and extra information
             ('bob lissner v. test 1 U.S. 12, 347-348 (4th Cir. 1982)',
              [case_citation(4, page='12', year=1982,
@@ -141,7 +146,7 @@ class FindTest(TestCase):
                                       'parenthetical': 'overruling foo'}),
               case_citation(4, page='2', reporter='S. Ct.', year=1982,
                             metadata={'plaintiff': 'lissner',
-                                      'defendant': 'test 1 U.S. 12, 347-348,',
+                                      'defendant': 'test 1 U.S. 12, 347-348',
                                       'court': 'ca4',
                                       'pin_cite': '358',
                                       'parenthetical': 'overruling foo'}),
@@ -360,7 +365,7 @@ class FindTest(TestCase):
             # Token scanning edge case -- incomplete paren at end of input
             ('1 U.S. 1 (', [case_citation(0)]),
             # Token scanning edge case -- missing plaintiff name at start of input
-            ('v. Bar, 1 U.S. 1', [case_citation(0, metadata={'defendant': 'Bar,'})]),
+            ('v. Bar, 1 U.S. 1', [case_citation(0, metadata={'defendant': 'Bar'})]),
             # Token scanning edge case -- short form start of input
             ('1 U.S., at 1', [case_citation(0, short=True)]),
             (', 1 U.S., at 1', [case_citation(0, short=True)]),

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -151,6 +151,18 @@ class FindTest(TestCase):
                                       'pin_cite': '358',
                                       'parenthetical': 'overruling foo'}),
               ]),
+            # Test full citation with nested parenthetical
+            ('lissner v. test 1 U.S. 1 (1982) (discussing abc (Holmes, J., concurring))',
+             [case_citation(6, metadata={'plaintiff': 'lissner',
+                                         'defendant': 'test',
+                                         'parenthetical': 'discussing abc (Holmes, J., concurring)'},
+                            year=1982)]),
+            # Test full citation with parenthetical and subsequent unrelated parenthetical
+            ('lissner v. test 1 U.S. 1 (1982) (discussing abc); blah (something).',
+             [case_citation(6, metadata={'plaintiff': 'lissner',
+                                         'defendant': 'test',
+                                         'parenthetical': 'discussing abc'},
+                            year=1982)]),
             # Test with text before and after and a variant reporter
             ('asfd 22 U. S. 332 (1975) asdf',
              [case_citation(1, page='332', volume='22',
@@ -245,6 +257,88 @@ class FindTest(TestCase):
                             metadata={'pin_cite': '20-25',
                                       'antecedent_guess': 'asdf',
                                       'court': 'scotus'})]),
+            # Test short form citation with a parenthetical
+            ('before asdf, 1 U. S., at 2 (overruling xyz)',
+             [case_citation(4, page='2', reporter='U.S.',
+                            reporter_found='U. S.', short=True,
+                            metadata={'antecedent_guess': 'asdf',
+                                      'parenthetical': 'overruling xyz',
+                                      'court': 'scotus'}
+                            )]),
+            # Test short form citation with no space before parenthetical
+            ('before asdf, 1 U. S., at 2 (overruling xyz)',
+             [case_citation(4, page='2', reporter='U.S.',
+                            reporter_found='U. S.', short=True,
+                            metadata={'antecedent_guess': 'asdf',
+                                      'parenthetical': 'overruling xyz',
+                                      'court': 'scotus'}
+                            )]),
+            # Test short form citation with nested parentheticals
+            ('before asdf, 1 U. S., at 2 (discussing xyz (Holmes, J., concurring))',
+             [case_citation(4, page='2', reporter='U.S.',
+                            reporter_found='U. S.', short=True,
+                            metadata={'antecedent_guess': 'asdf',
+                                      'parenthetical': 'discussing xyz (Holmes, J., concurring)',
+                                      'court': 'scotus'}
+                            )]),
+            # Test that short form citation doesn't treat year as parenthetical
+            ('before asdf, 1 U. S., at 2 (2016)',
+             [case_citation(4, page='2', reporter='U.S.',
+                            reporter_found='U. S.', short=True,
+                            metadata={'antecedent_guess': 'asdf',
+                                      'court': 'scotus'}
+                            )]),
+            # Test short form citation with page range and parenthetical
+            ('before asdf, 1 U. S., at 20-25 (overruling xyz)',
+             [case_citation(4, page='20', reporter='U.S.',
+                            reporter_found='U. S.', short=True,
+                            metadata={'antecedent_guess': 'asdf',
+                                      'pin_cite': '20-25',
+                                      'parenthetical': 'overruling xyz',
+                                      'court': 'scotus'}
+                            )]),
+            # Test short form citation with subsequent unrelated parenthetical
+            ('asdf, 1 U. S., at 4 (discussing abc). Some other nonsense (clarifying nonsense)',
+             [case_citation(2, page='4', reporter='U.S.',
+                            reporter_found='U. S.', short=True,
+                            metadata={'antecedent_guess': 'asdf',
+                                      'court': 'scotus',
+                                      'parenthetical': 'discussing abc'}
+                            )]
+             ),
+            # Test parenthetical matching with multiple citations
+            ('1 U. S., at 2. foo v. bar 3 U. S. 4 (2010) (overruling xyz).',
+             [case_citation(0, page='2', reporter='U.S.',
+                            reporter_found='U. S.',
+                            short=True, volume='1',
+                            metadata={'pin_cite': '2',
+                                      'court': 'scotus'}
+                            ),
+              case_citation(9, page='4', reporter='U.S.',
+                            reporter_found='U. S.', short=False,
+                            year=2010, volume='3',
+                            metadata={'parenthetical': 'overruling xyz',
+                                      'plaintiff': 'foo', 'defendant': 'bar',
+                                      'court': 'scotus'}
+                            )
+              ]),
+            # Test with multiple citations and parentheticals
+            ('1 U. S., at 2 (criticizing xyz). foo v. bar 3 U. S. 4 (2010) (overruling xyz).',
+             [case_citation(0, page='2', reporter='U.S.',
+                            reporter_found='U. S.',
+                            short=True, volume='1',
+                            metadata={'pin_cite': '2',
+                                      'court': 'scotus',
+                                      'parenthetical': 'criticizing xyz'}
+                            ),
+              case_citation(12, page='4', reporter='U.S.',
+                            reporter_found='U. S.', short=False,
+                            year=2010, volume='3',
+                            metadata={'parenthetical': 'overruling xyz',
+                                      'plaintiff': 'foo', 'defendant': 'bar',
+                                      'court': 'scotus'}
+                            )
+              ]),
             # Test first kind of supra citation (standard kind)
             ('before asdf, supra, at 2',
              [supra_citation(2, "supra,",

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -266,7 +266,7 @@ class FindTest(TestCase):
                                       'court': 'scotus'}
                             )]),
             # Test short form citation with no space before parenthetical
-            ('before asdf, 1 U. S., at 2 (overruling xyz)',
+            ('before asdf, 1 U. S., at 2(overruling xyz)',
              [case_citation(4, page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -51,7 +51,7 @@ class UtilsTest(TestCase):
             * year='1999'
             * court='scotus'
             * plaintiff='Foo'
-            * defendant='Bar,'
+            * defendant='Bar'
           * year=1999
         """
         )


### PR DESCRIPTION
Note: This description has been rewritten to reflect the new contents of this PR.

This PR improves and expands parenthetical support. It also partially fixes an issue in the test code causing tests to silently fail. Specifically, it does the following things:
- Modifies the parenthetical matching regex to allow for proper capturing of parentheticals with nested parentheticals.
  - For example: a citation like 'foo v. bar, 1 U.S. 3 (2021) (quoting baz (Holmes, J., concurring) and) 
  - Because we no longer cut off matching at the first closing paren found in the string, the regex could potentially capture more than one parenthetical (e.g. the parenthetical for `foo v. bar, 1 U.S. 3 (2021) (overruling baz) and something else (unrelated parenthetical).` would be captured as `overruling baz) and something else (unrelated parenthetical`.) This is addressed by adding the `process_parenthetical` helper method which counts parentheses to ensure only the first parenthetical is captured.
- Adds support for grabbing parentheticals on short form citations.\* Implements a new regex to match both the pin citation and parenthetical of these citations.
- Partially fixes the silent test failures described in #67. The silent failure is fixed by returning a value from `get_comparison_attrs`. Previously-silent failures related to a missing `court` metadata value are fixed in https://github.com/freelawproject/eyecite/pull/62/commits/a50c8ebb8015421aa2b5102ca5acbafa45c6955e, but because there are a substantial number of index mismatches and I don't currently understand the index logic, I disabled index comparison with a comment so that it can be fixed later. In the meantime, we at least get useful CI for everything else. Closes #67.
- Strips trailing commas off of defendant values. Closes #66.
- Adds a ton of tests to ensure this functionality works correctly and does not overzealously or underzealously capture parentheticals.

This PR implements a few changes that are only loosely related, so I'm happy to split this out into multiple PRs if necessary.

\* One upshot of the way I implemented this functionality in `extract_pin_citation` is that parentheticals attached to Id and Supra citations are now also captured. They are not used, however, because the Id and Supra citation classes don't currently have a parenthetical field in their metadata. I'm a little wary of tampering with a class model I don't fully understand at the moment, so I'll leave that to you guys.