### PR TITLE
Add setuptools to build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,4 +72,5 @@ good-names = "i,j,k,ex,Run,_,m"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core>=1.0.0"]
+# including "setuptools" allows for "pip install -e /path/to/eyecite"
+requires = ["poetry-core>=1.0.0", "setuptools"]


### PR DESCRIPTION
I don't know if this is actually correct, but if I try to install eyecite in editable mode like "pip install -e /path/to/eyecite", I get "ModuleNotFoundError: No module named 'setuptools'" unless this is included. This way it seems to work.