### PR TITLE
Add extraction of laws.json and journals.json patterns from reporters_db

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,11 +207,11 @@ of tokens:
     In [2]: list(default_tokenizer.tokenize("Foo v. Bar, 123 U.S. 456 (2016). Id. at 457."))
     Out[2]:
     ['Foo',
-     StopWordToken(data='v.', stop_word='v'),
+     StopWordToken(data='v.', ...),
      'Bar,',
-     CitationToken(data='123 U.S. 456', volume='123', reporter='U.S.', page='456' ...),
+     CitationToken(data='123 U.S. 456', volume='123', reporter='U.S.', page='456', ...),
      '(2016).',
-     IdToken(data='Id.'),
+     IdToken(data='Id.', ...),
      'at',
      '457.']
 

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -7,116 +7,27 @@ from courts_db import courts
 from eyecite.models import (
     CaseCitation,
     CitationBase,
+    FullJournalCitation,
+    FullLawCitation,
     ParagraphToken,
     StopWordToken,
     Token,
     Tokens,
 )
+from eyecite.regexes import (
+    PIN_CITE_REGEX,
+    POST_CITATION_REGEX,
+    POST_JOURNAL_CITATION_REGEX,
+    POST_LAW_CITATION_REGEX,
+)
 from eyecite.utils import strip_punct
 
-# *** Metadata regexes: ***
-# Regexes used to scan forward or backward from a citation token. NOTE:
-# * Regexes are written in verbose mode. Intentional spaces must be escaped.
-# * In many regexes order matters: options separated by "|" are
-#   tested left to right, so more specific (typically longer) have to come
-#   before less specific.
-
-# Pin cite regex:
-# A pin cite is the part of a citation used to specify a particular section of
-# the referenced document. These may have prefixes, may include paragraph,
-# page, or line references, and may have multiple ranges specified.
-# For some examples see
-# https://github.com/freelawproject/courtlistener/issues/1344#issuecomment-662994948
-PIN_CITE_TOKEN_REGEX = r"""
-    # optional label (longest to shortest):
-    (?:
-        (?:
-            (?:&\ )?note|       # note, & note
-            (?:&\ )?nn?\.?|     # n., nn., & nn.
-            (?:&\ )?fn?\.?|     # fn., & fn.
-            ¶{1,2}|             # ¶
-            §{1,2}|             # §
-            \*{1,4}|            # *
-            pg\.?|              # pg.
-            pp?\.?              # p., pp.
-        )\ ?  # optional space after label
-    )?
-    (?:
-        # page:paragraph cite, like 123:24-25 or 123:24-124:25:
-        \d+:\d+(?:-\d+(?::\d+)?)?|
-        # page range, like 12 or 12-13:
-        \d+(?:-\d+)?
-    )
-"""
-PIN_CITE_REGEX = rf"""
-    \ ?(?P<pin_cite>
-        (?:at\ )?
-        {PIN_CITE_TOKEN_REGEX},?
-        (?:\ {PIN_CITE_TOKEN_REGEX},?)*
-    )
-"""
-
-
-# Short cite antecedent regex:
-# What case does a short cite refer to? For now, we just capture the previous
-# word optionally followed by a comma. Example: Adarand, 515 U.S. at 241.
-SHORT_CITE_ANTECEDENT_REGEX = r"""
-    (?P<antecedent>[\w\-.]+),?
-    \   # final space
-"""
-
-
-# Supra cite antecedent regex:
-# What case does a short cite refer to? For now, we just capture the previous
-# word optionally followed by a comma. Example: Adarand, supra.
-# If the previous word is a digit, we capture both that (to store as a volume)
-# and the word before it (to store as antecedent).
-SUPRA_ANTECEDENT_REGEX = r"""
-    (?:
-        (?P<antecedent>[\w\-.]+),?\ (?P<volume>\d+)|
-        (?P<volume>\d+)|
-        (?P<antecedent>[\w\-.]+),?
-    )
-    \   # final space
-"""
-
-
-# Post citation regex:
-# Capture metadata after a full cite. For example given the citation "1 U.S. 1"
-# with the following text:
-#   1 U.S. 1, 4-5, 2 S. Ct. 2, 6-7 (4th Cir. 2012) (overruling foo)
-# we want to capture:
-#   pin_cite = 4-5
-#   extra = 2 S. Ct. 2, 6-7
-#   court = 4th Cir.
-#   year = 2012
-#   parenthetical = overruling foo
-POST_CITATION_REGEX = rf"""
-    (?:  # handle a full cite with a valid year paren:
-        # content before year paren:
-        (?:
-            # pin cite with comma and extra:
-            ,{PIN_CITE_REGEX},\ (?P<extra>[^(]+)|
-            # just pin cite:
-            ,{PIN_CITE_REGEX}\ |
-            # just extra
-            (?P<extra>[^(]*)
-        )
-        # content within year paren:
-        \((?:
-            # court and year:
-            (?P<court>[^)]+)\ (?P<year>\d{{4}})|
-            # just year:
-            (?P<year>\d{{4}})
-        )\)
-        # optional parenthetical comment:
-        (?:\ \((?P<parenthetical>[^)]+)\))?
-    |  # handle a pin cite with no valid year paren:
-        ,{PIN_CITE_REGEX}(?:,|\.|\ \()
-    )
-"""
-
 BACKWARD_SEEK = 28  # Median case name length in the CL db is 28 (2016-02-26)
+
+# Maximum characters to scan using match_on_tokens.
+# If this is higher we have to do a little more work for each match_on_tokens
+# call to prepare the text to be matched.
+MAX_MATCH_CHARS = 300
 
 
 def get_court_by_paren(paren_string: str) -> Optional[str]:
@@ -166,12 +77,14 @@ def add_post_citation(citation: CaseCitation, words: Tokens) -> None:
     See POST_CITATION_REGEX for examples.
     """
     m = match_on_tokens(
-        words, citation.index + 1, POST_CITATION_REGEX, max_chars=150
+        words,
+        citation.index + 1,
+        POST_CITATION_REGEX,
     )
     if not m:
         return
 
-    citation.pin_cite = m["pin_cite"]
+    citation.pin_cite = clean_pin_cite(m["pin_cite"]) or None
     citation.extra = (m["extra"] or "").strip() or None
     citation.parenthetical = m["parenthetical"]
     if m["year"]:
@@ -193,7 +106,7 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
             # Skip it
             continue
         if isinstance(word, StopWordToken):
-            if word.stop_word == "v" and index > 0:
+            if word.groups["stop_word"] == "v" and index > 0:
                 citation.plaintiff = "".join(
                     str(w) for w in words[max(index - 2, 0) : index]
                 ).strip()
@@ -208,6 +121,45 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
         ).strip()
 
 
+def add_law_metadata(citation: FullLawCitation, words: Tokens) -> None:
+    """Annotate FullLawCitation with pin_cite, publisher, etc."""
+    m = match_on_tokens(
+        words, citation.index + 1, POST_LAW_CITATION_REGEX, strings_only=True
+    )
+    if not m:
+        return
+
+    citation.pin_cite = clean_pin_cite(m["pin_cite"]) or None
+    citation.publisher = m["publisher"]
+    citation.day = m["day"]
+    citation.month = m["month"]
+    citation.year = m["year"]
+    citation.parenthetical = m["parenthetical"]
+
+
+def add_journal_metadata(citation: FullJournalCitation, words: Tokens) -> None:
+    """Annotate FullJournalCitation with pin_cite, year, etc."""
+    m = match_on_tokens(
+        words,
+        citation.index + 1,
+        POST_JOURNAL_CITATION_REGEX,
+        strings_only=True,
+    )
+    if not m:
+        return
+
+    citation.pin_cite = clean_pin_cite(m["pin_cite"]) or None
+    citation.year = m["year"]
+    citation.parenthetical = m["parenthetical"]
+
+
+def clean_pin_cite(pin_cite: Optional[str]) -> Optional[str]:
+    """Strip spaces and commas from pin_cite, if it is not None."""
+    if pin_cite is None:
+        return pin_cite
+    return pin_cite.strip(", ")
+
+
 def extract_pin_cite(
     words: Tokens, index: int, prefix: str = ""
 ) -> Tuple[Optional[str], Optional[int]]:
@@ -220,7 +172,7 @@ def extract_pin_cite(
         words, index + 1, PIN_CITE_REGEX, prefix=prefix, strings_only=True
     )
     if m:
-        pin_cite = m["pin_cite"]
+        pin_cite = clean_pin_cite(m["pin_cite"]) or None
         extra_chars = m.span(1)[1]
         return pin_cite, from_token.end + extra_chars - len(prefix)
     return None, None
@@ -231,7 +183,6 @@ def match_on_tokens(
     start_index,
     regex,
     prefix="",
-    max_chars=100,
     strings_only=False,
     forward=True,
     flags=re.X,
@@ -273,15 +224,15 @@ def match_on_tokens(
             text = str(token) + text
 
         # check for max length
-        if len(text) >= max_chars:
-            text = text[:max_chars]
+        if len(text) >= MAX_MATCH_CHARS:
+            text = text[:MAX_MATCH_CHARS]
             break
 
     m = re.search(regex, text, flags=flags)
     # Useful for debugging regex failures:
-    # print(
-    #     f"Regex: {regex}\nText: {text}\nMatch: {m.groups() if m else None}"
-    # )
+    # print(f"Regex: {regex}")
+    # print(f"Text: {repr(text)}")
+    # print(f"Match: {m.groupdict() if m else None}")
     return m
 
 
@@ -296,7 +247,7 @@ def disambiguate_reporters(
     ]
 
 
-joke_cite: List[CaseCitation] = [
+joke_cite: List[CitationBase] = [
     CaseCitation(
         Token("1 FLP 1", 0, 7),
         0,

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -2,16 +2,7 @@ import re
 from collections import UserString
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import (
-    Callable,
-    ClassVar,
-    Dict,
-    Hashable,
-    List,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import Callable, Dict, Hashable, List, Optional, Sequence, Union
 
 ResourceType = Hashable
 
@@ -23,6 +14,7 @@ class Reporter:
     short_name: str
     name: str
     cite_type: str
+    source: str  # one of "reporters", "laws", "journals"
     is_scotus: bool = False
 
     def __post_init__(self):
@@ -64,13 +56,32 @@ class CitationBase:
     # span() overrides
     span_start: Optional[int] = None
     span_end: Optional[int] = None
+    groups: dict = field(default_factory=dict, compare=False)
+
+    def __post_init__(self):
+        """Set groups."""
+        self.groups = self.token.groups
+
+    def __repr__(self):
+        """Simplified repr() to be more readable than full dataclass repr().
+        Just shows 'FullCaseCitation("matched text", groups=...)'."""
+        return (
+            f"{self.__class__.__name__}("
+            + f"{repr(self.matched_text())}"
+            + (f", groups={repr(self.groups)}" if self.groups else "")
+            + ")"
+        )
+
+    def formatted(self):
+        """Return formatted version of extracted cite."""
+        return self.matched_text()
 
     def matched_text(self):
         """Text that identified this citation, such as '1 U.S. 1' or 'Id.'"""
         return str(self.token)
 
     def span(self):
-        """Start and stop offsets in source text for matched_text.()"""
+        """Start and stop offsets in source text for matched_text()."""
         return (
             self.span_start
             if self.span_start is not None
@@ -79,44 +90,28 @@ class CitationBase:
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
-class CaseCitation(CitationBase):
-    """Convenience class which represents a single citation found in a
-    document.
-    """
+@dataclass(eq=True, unsafe_hash=True, repr=False)
+class ResourceCitation(CitationBase):
+    """Base class for a case, law, or journal citation. Could be short or
+    long."""
 
-    # Core data.
+    # Value of the 'reporter' match group, for normalizing variations
+    reporter_found: Optional[str] = None
     reporter: Optional[str] = None
-    page: Optional[str] = None
-    volume: Optional[str] = None
 
     # Set during disambiguation.
     # For a citation to F.2d, the canonical reporter is F.
     canonical_reporter: Optional[str] = None
-
-    # Supplementary data, if possible:
-    #  <plaintiff> v. <defendant>,
-    #  <matched_text> <pin_cite> <extra>
-    #  (<court> <year>)
-    #  (<parenthetical).
-    plaintiff: Optional[str] = None
-    defendant: Optional[str] = None
-    pin_cite: Optional[str] = None
-    extra: Optional[str] = None
-    court: Optional[str] = None
-    year: Optional[int] = None
-    parenthetical: Optional[str] = None
-
-    # The reporter found in the text is often different from the reporter
-    # once it's normalized. We need to keep the original value so we can
-    # linkify it with a regex.
-    reporter_found: Optional[str] = None
 
     # Editions that might match this reporter string
     exact_editions: Sequence[Edition] = field(default_factory=tuple)
     variation_editions: Sequence[Edition] = field(default_factory=tuple)
     all_editions: Sequence[Edition] = field(default_factory=tuple)
     edition_guess: Optional[Edition] = None
+
+    parenthetical: Optional[str] = None
+    pin_cite: Optional[str] = None
+    year: Optional[int] = None
 
     def __post_init__(self):
         """Make iterables into tuples to make sure we're hashable."""
@@ -125,29 +120,16 @@ class CaseCitation(CitationBase):
         self.all_editions = tuple(self.exact_editions) + tuple(
             self.variation_editions
         )
+        super().__post_init__()
 
     def base_citation(self):
         """Return a simple version of the citation."""
-        return "%s %s %s" % (self.volume, self.reporter, self.page)
-
-    def __repr__(self):
-        print_string = self.base_citation()
-        if self.defendant:
-            print_string = " ".join([self.defendant, print_string])
-            if self.plaintiff:
-                print_string = " ".join([self.plaintiff, "v.", print_string])
-        if self.extra:
-            print_string = " ".join([print_string, self.extra])
-        if self.court and self.year:
-            paren = "(%s %d)" % (self.court, self.year)
-        elif self.year:
-            paren = "(%d)" % self.year
-        elif self.court:
-            paren = "(%s)" % self.court
-        else:
-            paren = ""
-        print_string = " ".join([print_string, paren])
-        return print_string
+        if self.edition_guess:
+            # normalize reporter
+            return self.matched_text().replace(
+                self.reporter_found, self.edition_guess.short_name
+            )
+        return self.matched_text()
 
     def guess_edition(self):
         """Set canonical_reporter, edition_guess, and reporter."""
@@ -165,6 +147,70 @@ class CaseCitation(CitationBase):
             self.canonical_reporter = editions[0].reporter.short_name
             self.reporter = editions[0].short_name
 
+
+@dataclass(eq=True, unsafe_hash=True, repr=False)
+class FullCitation(ResourceCitation):
+    """Abstract base class indicating cite fully identifies a resource."""
+
+
+@dataclass(eq=True, unsafe_hash=True, repr=False)
+class FullLawCitation(FullCitation):
+    """Citation to a source from laws.json."""
+
+    publisher: Optional[str] = None
+    day: Optional[str] = None
+    month: Optional[str] = None
+
+
+@dataclass(eq=True, unsafe_hash=True, repr=False)
+class FullJournalCitation(FullCitation):
+    """Citation to a source from journals.json."""
+
+    # Core data.
+    page: Optional[str] = None
+    volume: Optional[str] = None
+
+
+@dataclass(eq=True, unsafe_hash=True, repr=False)
+class CaseCitation(ResourceCitation):
+    """Convenience class which represents a single citation found in a
+    document.
+    """
+
+    # Core data.
+    page: Optional[str] = None
+    volume: Optional[str] = None
+
+    # Supplementary data, if possible:
+    #  <plaintiff> v. <defendant>,
+    #  <matched_text> <pin_cite> <extra>
+    #  (<court> <year>)
+    #  (<parenthetical).
+    plaintiff: Optional[str] = None
+    defendant: Optional[str] = None
+    extra: Optional[str] = None
+    court: Optional[str] = None
+
+    def formatted(self):
+        """Return formatted version of extracted cite."""
+        parts = []
+        if self.plaintiff:
+            parts.append(f"{self.plaintiff} v. ")
+        if self.defendant:
+            parts.append(f"{self.defendant}, ")
+        parts.append(self.base_citation())
+        if self.pin_cite:
+            parts.append(f", {self.pin_cite}")
+        if self.extra:
+            parts.append(self.extra)
+        if self.court or self.year:
+            parts.append(" (")
+            parts.append(" ".join(i for i in (self.court, self.year) if i))
+            parts.append(")")
+        if self.parenthetical:
+            parts.append(f" ({self.parenthetical})")
+        return "".join(parts)
+
     def guess_court(self):
         """Set court based on reporter."""
         if not self.court and any(
@@ -173,8 +219,8 @@ class CaseCitation(CitationBase):
             self.court = "scotus"
 
 
-@dataclass(eq=True, unsafe_hash=True)
-class FullCaseCitation(CaseCitation):
+@dataclass(eq=True, unsafe_hash=True, repr=False)
+class FullCaseCitation(CaseCitation, FullCitation):
     """Convenience class which represents a standard, fully named citation,
     i.e., the kind of citation that marks the first time a document is cited.
 
@@ -182,7 +228,7 @@ class FullCaseCitation(CaseCitation):
     """
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True, repr=False)
 class ShortCaseCitation(CaseCitation):
     """Convenience class which represents a short form citation, i.e., the kind
     of citation made after a full citation has already appeared. This kind of
@@ -198,17 +244,16 @@ class ShortCaseCitation(CaseCitation):
     # and the page number is non-canonical
     antecedent_guess: Optional[str] = None
 
-    def __repr__(self):
-        print_string = "%s, %s %s, at %s" % (
-            self.antecedent_guess,
-            self.volume,
-            self.reporter,
-            self.page,
-        )
-        return print_string
+    def formatted(self):
+        """Return formatted version of extracted cite."""
+        parts = []
+        if self.antecedent_guess:
+            parts.append(f"{self.antecedent_guess}, ")
+        parts.append(self.base_citation())
+        return "".join(parts)
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True, repr=False)
 class SupraCitation(CitationBase):
     """Convenience class which represents a 'supra' citation, i.e., a citation
     to something that is above in the document. Like a short form citation,
@@ -227,11 +272,20 @@ class SupraCitation(CitationBase):
     pin_cite: Optional[str] = None
     volume: Optional[str] = None
 
-    def __repr__(self):
-        return "%s supra, %s" % (self.antecedent_guess, self.pin_cite)
+    def formatted(self):
+        """Return formatted version of extracted cite."""
+        parts = []
+        if self.antecedent_guess:
+            parts.append(f"{self.antecedent_guess}, ")
+        if self.volume:
+            parts.append(f"{self.volume} ")
+        parts.append("supra")
+        if self.pin_cite:
+            parts.append(f", {self.pin_cite}")
+        return "".join(parts)
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True, repr=False)
 class IdCitation(CitationBase):
     """Convenience class which represents an 'id' or 'ibid' citation, i.e., a
     citation to the document referenced immediately prior. An 'id' citation is
@@ -244,11 +298,15 @@ class IdCitation(CitationBase):
 
     pin_cite: Optional[str] = None
 
-    def __repr__(self):
-        return "%s %s" % (self.token, self.pin_cite)
+    def formatted(self):
+        """Return formatted version of extracted cite."""
+        parts = ["id."]
+        if self.pin_cite:
+            parts.append(f", {self.pin_cite}")
+        return "".join(parts)
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True, repr=False)
 class NonopinionCitation(CitationBase):
     """Convenience class which represents a citation to something that we know
     is not an opinion. This could be a citation to a statute, to the U.S. code,
@@ -267,6 +325,7 @@ class Token(UserString):
     data: str
     start: int
     end: int
+    groups: dict = field(default_factory=dict, compare=False)
 
     @classmethod
     def from_match(cls, m, extra, offset=0) -> "Token":
@@ -274,7 +333,11 @@ class Token(UserString):
         This gets called by TokenExtractor. By default, just use the
         entire matched string."""
         start, end = m.span(1)
-        return cls(m[1], start + offset, end + offset)
+        # ignore "too many arguments" type error -- this is called
+        # by subclasses with additional attributes
+        return cls(  # type: ignore[call-arg]
+            m[1], start + offset, end + offset, groups=m.groupdict(), **extra
+        )
 
 
 # For performance, lists of tokens can include either Token subclasses
@@ -286,15 +349,11 @@ Tokens = List[TokenOrStr]
 
 @dataclass(eq=True, frozen=True)
 class CitationToken(Token):
-    """String matching a citation regex."""
+    """String matching a citation regex from reporters.json."""
 
-    volume: str
-    reporter: str
-    page: str
     exact_editions: Sequence[Edition] = field(default_factory=tuple)
     variation_editions: Sequence[Edition] = field(default_factory=tuple)
     short: bool = False
-    extra_match_groups: dict = field(default_factory=dict, compare=False)
 
     def __post_init__(self):
         """Make iterables into tuples to make sure we're hashable."""
@@ -302,25 +361,6 @@ class CitationToken(Token):
         object.__setattr__(self, "exact_editions", tuple(self.exact_editions))
         object.__setattr__(
             self, "variation_editions", tuple(self.variation_editions)
-        )
-
-    @classmethod
-    def from_match(cls, m, extra, offset=0) -> Token:
-        """Citation regex matches have volume, reporter, and page match groups
-        in their regular expressions, and "exact_editions" and
-        "variation_editions" in their extra config. Pass all of that through
-        to the constructor."""
-        start, end = m.span(1)
-        match_groups = m.groupdict()
-        return cls(
-            m[1],
-            start + offset,
-            end + offset,
-            volume=match_groups.pop("volume", ""),
-            reporter=match_groups.pop("reporter", ""),
-            page=match_groups.pop("page", ""),
-            extra_match_groups=match_groups,
-            **extra,
         )
 
 
@@ -347,29 +387,6 @@ class ParagraphToken(Token):
 @dataclass(eq=True, frozen=True)
 class StopWordToken(Token):
     """Word matching one of the STOP_TOKENS."""
-
-    stop_word: str
-    stop_tokens: ClassVar[Sequence[str]] = (
-        "v",
-        "re",
-        "parte",
-        "denied",
-        "citing",
-        "aff'd",
-        "affirmed",
-        "remanded",
-        "see",
-        "granted",
-        "dismissed",
-    )
-
-    @classmethod
-    def from_match(cls, m, extra, offset=0) -> Token:
-        """m[1] is the captured part of the match, including punctuation.
-        m[2] is just the underlying stopword like 'v', useful for comparison.
-        """
-        start, end = m.span(1)
-        return cls(m[1], start + offset, end + offset, m[2].lower())
 
 
 @dataclass
@@ -412,16 +429,14 @@ class Resource(ResourceType):
     """Thin resource class representing an object to which a citation can be
     resolved."""
 
-    citation: FullCaseCitation
+    citation: FullCitation
 
     def __hash__(self):
         """
-        Resources are constructively equal if the core attributes of their
-        citations are equal.
+        Full citations are constructively equal if the groups matched by their
+        regexes are equal.
         """
-        return hash(
-            (self.citation.reporter, self.citation.volume, self.citation.page)
-        )
+        return hash((type(self.citation), tuple(self.citation.groups.items())))
 
     def __eq__(self, other):
         return self.__hash__() == other.__hash__()

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -1,0 +1,271 @@
+# *** Helpers for building regexes: ***
+
+
+def space_boundaries_re(regex):
+    """Wrap regex with space or end of string."""
+    return rf"(?:^|\s)({regex})(?:\s|$)"
+
+
+def strip_punctuation_re(regex):
+    """Wrap regex with punctuation pattern."""
+    return rf"{PUNCTUATION_REGEX}{regex}{PUNCTUATION_REGEX}"
+
+
+def nonalphanum_boundaries_re(regex):
+    """Wrap regex to require non-alphanumeric characters on left and right."""
+    return rf"(?:^|[^a-zA-Z0-9])({regex})(?:[^a-zA-Z0-9]|$)"
+
+
+# *** Tokenizer regexes: ***
+# Regexes used from tokenizers.py
+
+# We need a regex that matches roman numerals but not the empty string,
+# without using lookahead assertions that aren't supported by hyperscan.
+# We *don't* want to match roman numerals 'v', 'l', or 'c', or numerals over
+# 200, or uppercase, as these are usually false positives
+# (see https://github.com/freelawproject/eyecite/issues/56 ).
+# Match roman numerals 1 to 199 except for 5, 50, 100:
+ROMAN_NUMERAL_REGEX = "|".join(
+    [
+        # 10-199, but not 50-59 or 100-109 or 150-159:
+        r"c?(?:xc|xl|l?x{1,3})(?:ix|iv|v?i{0,3})",
+        # 1-9, 51-59, 101-109, 151-159, but not 5, 55, 105, 155:
+        r"(?:c?l?)(?:ix|iv|v?i{1,3})",
+        # 55, 105, 150, 155:
+        r"(?:lv|cv|cl|clv)",
+    ]
+)
+
+# Page number regex to match one of the following:
+# (ordered in descending order of likelihood)
+# 1) A plain digit. E.g. "123"
+# 2) A roman numeral.
+PAGE_NUMBER_REGEX = rf"(?:\d+|{ROMAN_NUMERAL_REGEX})"
+
+# Regex to match punctuation around volume numbers and stopwords.
+# This could potentially be more precise.
+PUNCTUATION_REGEX = r"[^\sa-zA-Z0-9]*"
+
+# Regex for IdToken
+ID_REGEX = space_boundaries_re(r"id\.,?|ibid\.")
+
+# Regex for SupraToken
+SUPRA_REGEX = space_boundaries_re(strip_punctuation_re("supra"))
+
+# Regex for StopWordToken
+STOP_WORDS = (
+    "v",
+    "re",
+    "parte",
+    "denied",
+    "citing",
+    "aff'd",
+    "affirmed",
+    "remanded",
+    "see",
+    "granted",
+    "dismissed",
+)
+STOP_WORD_REGEX = space_boundaries_re(
+    strip_punctuation_re(rf'(?P<stop_word>{"|".join(STOP_WORDS)})')
+)
+
+# Regex for SectionToken
+SECTION_REGEX = r"(\S*§\S*)"
+
+# Regex for ParagraphToken
+PARAGRAPH_REGEX = r"(\n)"
+
+
+# *** Metadata regexes: ***
+# Regexes used to scan forward or backward from a citation token. NOTE:
+# * Regexes are written in verbose mode. Intentional spaces must be escaped.
+# * In many regexes order matters: options separated by "|" are
+#   tested left to right, so more specific (typically longer) have to come
+#   before less specific.
+
+# Parenthetical regex:
+# Capture a parenthetical after a cite, like " (overruling Foo)"
+PARENTHETICAL_REGEX = r"""
+    (?:
+        # optional space, opening paren
+        \ ?\(
+        # capture non-closing-paren characters
+        (?P<parenthetical>[^)]+)
+    )?
+"""
+
+MONTH_REGEX = r"""
+    (?P<month>
+        Jan\.|Feb\.|Mar\.|Apr\.|May|June|
+        July|Aug\.|Sept\.|Oct\.|Nov\.|Dec\.
+    )
+"""
+
+YEAR_REGEX = r"""
+    (?P<year>
+        \d{4}
+    )
+    # Year is occasionally a range, like "1993-94" or "2005-06".
+    # For now we ignore the end of the range:
+    (?:-\d{2})?
+"""
+
+# Pin cite regex:
+# A pin cite is the part of a citation used to specify a particular section of
+# the referenced document. These may have prefixes, may include paragraph,
+# page, or line references, and may have multiple ranges specified.
+# For some examples see
+# https://github.com/freelawproject/courtlistener/issues/1344#issuecomment-662994948
+PIN_CITE_TOKEN_REGEX = r"""
+    # optional label (longest to shortest):
+    (?:
+        (?:
+            (?:&\ )?note|       # note, & note
+            (?:&\ )?nn?\.?|     # n., nn., & nn.
+            (?:&\ )?fn?\.?|     # fn., & fn.
+            ¶{1,2}|             # ¶
+            §{1,2}|             # §
+            \*{1,4}|            # *
+            pg\.?|              # pg.
+            pp?\.?              # p., pp.
+        )\ ?  # optional space after label
+    )?
+    (?:
+        # page:paragraph cite, like 123:24-25 or 123:24-124:25:
+        \d+:\d+(?:-\d+(?::\d+)?)?|
+        # page range, like 12 or 12-13:
+        \d+(?:-\d+)?
+    )
+"""
+PIN_CITE_REGEX = rf"""
+    (?P<pin_cite>
+        (?:,?\ ?at)?
+        (?:,?\ ?{PIN_CITE_TOKEN_REGEX})+
+        # pin cite must be followed by one of these so it doesn't capture
+        # start of next citation
+        (?=
+            [,.;)\]\\]|  # ending punctuation
+            \ [(\[]|   # space and start of parens
+            $          # end of text
+        )
+    )
+"""
+
+# Law subsection regex:
+# Capture a single subsection like "(a)", "(1)", or "(viii)":
+LAW_SUBSECTION = r"""
+    (?:
+        \([0-9a-zA-Z]{1,4}\)
+    )
+"""
+
+# Law pin cite regex:
+# Capture pin cite immediately after a law section number.
+# Examples:
+#  ...(a)(2)
+#  ...(a)(2) and (d)
+#  ... et seq.
+# We should also capture ranges like "123-124" here, but those are ambiguous
+# and are already captured as section numbers the same as "12-34-5".
+LAW_PIN_CITE_REGEX = rf"""
+    (?P<pin_cite>
+        # subsection like (a)(1)(xiii):
+        {LAW_SUBSECTION}*
+        (?:\ and\ {LAW_SUBSECTION}+)?
+        (?:\ et\ seq\.)?
+    )
+"""
+
+# Short cite antecedent regex:
+# What case does a short cite refer to? For now, we just capture the previous
+# word optionally followed by a comma. Example: Adarand, 515 U.S. at 241.
+SHORT_CITE_ANTECEDENT_REGEX = r"""
+    (?P<antecedent>[\w\-.]+),?
+    \   # final space
+"""
+
+
+# Supra cite antecedent regex:
+# What case does a short cite refer to? For now, we just capture the previous
+# word optionally followed by a comma. Example: Adarand, supra.
+# If the previous word is a digit, we capture both that (to store as a volume)
+# and the word before it (to store as antecedent).
+SUPRA_ANTECEDENT_REGEX = r"""
+    (?:
+        (?P<antecedent>[\w\-.]+),?\ (?P<volume>\d+)|
+        (?P<volume>\d+)|
+        (?P<antecedent>[\w\-.]+),?
+    )
+    \   # final space
+"""
+
+
+# Post citation regex:
+# Capture metadata after a full cite. For example given the citation "1 U.S. 1"
+# with the following text:
+#   1 U.S. 1, 4-5, 2 S. Ct. 2, 6-7 (4th Cir. 2012) (overruling foo)
+# we want to capture:
+#   pin_cite = 4-5
+#   extra = 2 S. Ct. 2, 6-7
+#   court = 4th Cir.
+#   year = 2012
+#   parenthetical = overruling foo
+POST_CITATION_REGEX = rf"""
+    (?:  # handle a full cite with a valid year paren:
+        # content before year paren:
+        (?:
+            # pin cite with comma and extra:
+            {PIN_CITE_REGEX}?
+            ,?\ ?
+            (?P<extra>[^(]*)
+        )
+        # content within year paren:
+        \((?:
+            # court and year:
+            (?P<court>[^)]+)\ {YEAR_REGEX}|
+            # just year:
+            {YEAR_REGEX}
+        )\)
+        # optional parenthetical comment:
+        {PARENTHETICAL_REGEX}
+    |  # handle a pin cite with no valid year paren:
+        {PIN_CITE_REGEX}
+    )
+"""
+
+# Post law citation regex:
+# statutory and regulatory cites may have publishers and dates after them, like
+#  (West), (West 1999), (Lexis Jun. 2018), (1999), or (May 2, 1999),
+# and then may be followed by a parenthetical:
+POST_LAW_CITATION_REGEX = rf"""
+    {LAW_PIN_CITE_REGEX}?
+    \ ?
+    (?:\(
+        # Consol., McKinney, Deering, West, LexisNexis, etc.
+        (?P<publisher>
+            [A-Z][a-z]+\.?
+            (?:\ Supp\.)?
+        )?
+        \ ?
+        # month
+        (?:{MONTH_REGEX}\ )?
+        # day
+        (?P<day>\d{{1,2}})?,?\ ?
+        # four-digit year
+        {YEAR_REGEX}?
+    \))?
+    \ ?
+    # parenthetical
+    {PARENTHETICAL_REGEX}
+"""
+
+# Post journal cite regex:
+# Journal cites may have a pin cite, then year, then parenthetical.
+POST_JOURNAL_CITATION_REGEX = rf"""
+    {PIN_CITE_REGEX}?
+    \ ?
+    (?:\({YEAR_REGEX}\))?
+    \ ?
+    {PARENTHETICAL_REGEX}
+"""

--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -1,6 +1,8 @@
 from eyecite.models import (
     CitationToken,
     FullCaseCitation,
+    FullJournalCitation,
+    FullLawCitation,
     IdCitation,
     IdToken,
     NonopinionCitation,
@@ -31,19 +33,82 @@ def case_citation(
     if short:
         kwargs.setdefault("pin_cite", page)
     edition = EDITIONS_LOOKUP[reporter][0]
+    groups = kwargs.pop("groups", {})
+    if volume:
+        groups.setdefault("volume", volume)
+    groups.setdefault("reporter", kwargs["reporter_found"])
+    groups.setdefault("page", page)
+    # Avoid https://github.com/PyCQA/pylint/issues/3201
+    # pylint: disable=unexpected-keyword-arg
     token = CitationToken(
         source_text,
         0,  # fake start offset
         99,  # fake end offset
-        volume,
-        reporter,
-        page,
+        groups=groups,
         exact_editions=[edition],
         variation_editions=[],
         short=short,
     )
     cls = ShortCaseCitation if short else FullCaseCitation
     return cls(
+        token, index, volume=volume, reporter=reporter, page=page, **kwargs
+    )
+
+
+def law_citation(
+    index,
+    source_text,
+    reporter,
+    **kwargs,
+):
+    """Convenience function for creating mock CaseCitation objects."""
+    kwargs.setdefault("canonical_reporter", reporter)
+    kwargs.setdefault("reporter_found", reporter)
+    edition = EDITIONS_LOOKUP[reporter][0]
+    groups = kwargs.pop("groups", {})
+    groups.setdefault("reporter", kwargs["reporter_found"])
+    # Avoid https://github.com/PyCQA/pylint/issues/3201
+    # pylint: disable=unexpected-keyword-arg
+    token = CitationToken(
+        source_text,
+        0,  # fake start offset
+        99,  # fake end offset
+        exact_editions=[edition],
+        variation_editions=[],
+        groups=groups,
+    )
+    return FullLawCitation(token, index, reporter=reporter, **kwargs)
+
+
+def journal_citation(
+    index,
+    source_text=None,
+    page="1",
+    reporter="Minn. L. Rev.",
+    volume="1",
+    **kwargs,
+):
+    """Convenience function for creating mock CaseCitation objects."""
+    kwargs.setdefault("canonical_reporter", reporter)
+    kwargs.setdefault("reporter_found", reporter)
+    if not source_text:
+        source_text = f"{volume} {reporter} {page}"
+    edition = EDITIONS_LOOKUP[reporter][0]
+    groups = kwargs.pop("groups", {})
+    groups.setdefault("volume", volume)
+    groups.setdefault("reporter", kwargs["reporter_found"])
+    groups.setdefault("page", page)
+    # Avoid https://github.com/PyCQA/pylint/issues/3201
+    # pylint: disable=unexpected-keyword-arg
+    token = CitationToken(
+        source_text,
+        0,  # fake start offset
+        99,  # fake end offset
+        groups=groups,
+        exact_editions=[edition],
+        variation_editions=[],
+    )
+    return FullJournalCitation(
         token, index, volume=volume, reporter=reporter, page=page, **kwargs
     )
 

--- a/eyecite/utils.py
+++ b/eyecite/utils.py
@@ -92,3 +92,10 @@ def hyperscan_match(regexes, text):
     hyperscan_db.scan(text.encode("utf8"), on_match)
 
     return matches
+
+
+class HashableDict(dict):
+    """Dict that works as an attribute of a hashable dataclass."""
+
+    def __hash__(self):
+        return hash(frozenset(self.items()))

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,7 +283,7 @@ python-versions = "*"
 
 [[package]]
 name = "reporters-db"
-version = "3.0.1"
+version = "3.1.1"
 description = "Database of Court Reporters"
 category = "main"
 optional = false
@@ -355,7 +355,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "922b4c963f445181457a543dfe726ed4524c0db19c3715ac21d4cf36040e1e82"
+content-hash = "cb27e4696c03d591f1722a5adb87cd61c19d73a891a0414d93edcc21f65863b8"
 
 [metadata.files]
 appdirs = [
@@ -603,8 +603,8 @@ regex = [
     {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
 ]
 reporters-db = [
-    {file = "reporters-db-3.0.1.tar.gz", hash = "sha256:ef90064c9e7782a4b8c5b00ca1d9d0d660d316736a6e9e78f81bdfee678b0b40"},
-    {file = "reporters_db-3.0.1-py2.py3-none-any.whl", hash = "sha256:e5a84e79e168babef457a85018875dc1f3528ba26a0e86078b520427089da076"},
+    {file = "reporters-db-3.1.1.tar.gz", hash = "sha256:d3da82e7a1520746d110afee994e1c470534d9d54536ea1fca2ea5a457b5c056"},
+    {file = "reporters_db-3.1.1-py2.py3-none-any.whl", hash = "sha256:4b2d49c9d0b48cdc875c6b998ffce69f0cff1058dd89c28041578776329a1c08"},
 ]
 roman = [
     {file = "roman-3.3-py2.py3-none-any.whl", hash = "sha256:c2a1f14ab47373aecc141edbcdd66595949c9d0ed932fe76bd547df1b55f7278"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = ["eyecite/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-reporters-db = "^3.0.1"
+reporters-db = "^3.1.1"
 courts-db = "^0.9.7"
 lxml = "^4.6.3"
 pyahocorasick = ">= 1.2"
@@ -69,6 +69,9 @@ disable = "C0330, C0326, C0114, R0901, W0613, E1121"
 max-line-length = "79"
 # allow "m" as a standard variable name for re Match objects
 good-names = "i,j,k,ex,Run,_,m"
+
+[tool.pylint.similarities]
+ignore-imports="yes"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_AnnotateTest.py
+++ b/tests/test_AnnotateTest.py
@@ -19,6 +19,18 @@ class AnnotateTest(TestCase):
             ("foo 1 U.S. 1 bar", "foo <0>1 U.S. 1</0> bar", []),
             # cite with punctuation
             ("foo '1 U.S. 1' bar", "foo '<0>1 U.S. 1</0>' bar", []),
+            # law cite
+            (
+                "foo. Mass. Gen. Laws ch. 1, § 2. bar",
+                "foo. <0>Mass. Gen. Laws ch. 1, § 2</0>. bar",
+                [],
+            ),
+            # journal cite
+            (
+                "foo. 1 Minn. L. Rev. 2. bar",
+                "foo. <0>1 Minn. L. Rev. 2</0>. bar",
+                [],
+            ),
             # Id. cite
             (
                 "1 U.S. 1. Foo. Id. Bar. Id. at 2.",

--- a/tests/test_RegexTest.py
+++ b/tests/test_RegexTest.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+
+import exrex
+import roman
+
+from eyecite.regexes import ROMAN_NUMERAL_REGEX
+
+
+class RegexesTest(TestCase):
+    def test_roman_numeral_regex(self):
+        """Make sure ROMAN_NUMERAL_REGEX matches all numbers between 1-199
+        except 5, 50, 100."""
+        expected = (
+            list(range(1, 5))
+            + list(range(6, 50))
+            + list(range(51, 100))
+            + list(range(101, 200))
+        )
+        actual = sorted(
+            roman.fromRoman(n.upper())
+            for n in exrex.generate(ROMAN_NUMERAL_REGEX)
+        )
+        self.assertEqual(actual, expected)

--- a/tests/test_ResolveTest.py
+++ b/tests/test_ResolveTest.py
@@ -15,23 +15,35 @@ from eyecite.test_factories import (
 
 full1 = case_citation(1)
 full2 = case_citation(2)
-full3 = case_citation(3, reporter="F.2d", plaintiff="Foo", defendant="Bar")
-full4 = case_citation(4, defendant="Bar")
-full5 = case_citation(5, plaintiff="Ipsum")
-full6 = case_citation(6, reporter="F.2d", plaintiff="Ipsum")
+full3 = case_citation(
+    3, reporter="F.2d", metadata={"plaintiff": "Foo", "defendant": "Bar"}
+)
+full4 = case_citation(4, metadata={"defendant": "Bar"})
+full5 = case_citation(5, metadata={"plaintiff": "Ipsum"})
+full6 = case_citation(6, reporter="F.2d", metadata={"plaintiff": "Ipsum"})
 full7 = case_citation(7, volume="1", reporter="U.S.")
-full8 = case_citation(8, reporter="F.2d", volume="2", defendant="Ipsum")
-full9 = case_citation(9, reporter="F.2d", page="99", defendant="Ipsum")
-full10 = case_citation(10, reporter="F.2d", plaintiff="Foo")
+full8 = case_citation(
+    8, reporter="F.2d", volume="2", metadata={"defendant": "Ipsum"}
+)
+full9 = case_citation(
+    9, reporter="F.2d", page="99", metadata={"defendant": "Ipsum"}
+)
+full10 = case_citation(10, reporter="F.2d", metadata={"plaintiff": "Foo"})
 
 short1 = case_citation(1, volume="1", reporter="U.S.", short=True)
-short2 = case_citation(2, antecedent_guess="Bar", short=True)
-short3 = case_citation(3, reporter="F.2d", plaintiff="Foo", short=True)
-short4 = case_citation(4, reporter="F.2d", defendant="wrong", short=True)
-short5 = case_citation(5, reporter="F.2d", defendant="Ipsum", short=True)
+short2 = case_citation(2, metadata={"antecedent_guess": "Bar"}, short=True)
+short3 = case_citation(
+    3, reporter="F.2d", metadata={"antecedent_guess": "Foo"}, short=True
+)
+short4 = case_citation(
+    4, reporter="F.2d", metadata={"antecedent_guess": "wrong"}, short=True
+)
+short5 = case_citation(
+    5, reporter="F.2d", metadata={"antecedent_guess": "Ipsum"}, short=True
+)
 
-supra1 = supra_citation(1, antecedent_guess="Bar")
-supra2 = supra_citation(2, antecedent_guess="Ipsum")
+supra1 = supra_citation(1, metadata={"antecedent_guess": "Bar"})
+supra2 = supra_citation(2, metadata={"antecedent_guess": "Ipsum"})
 
 id1 = id_citation(1)
 

--- a/tests/test_TokenizeTest.py
+++ b/tests/test_TokenizeTest.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from eyecite.models import CitationToken, IdToken, StopWordToken
+from eyecite.regexes import STOP_WORDS
 from eyecite.tokenizers import (
     EDITIONS_LOOKUP,
     AhocorasickTokenizer,
@@ -14,7 +15,11 @@ class TokenizerTest(TestCase):
         tokenize = default_tokenizer.tokenize
         us_reporter = EDITIONS_LOOKUP["U.S."][0]
         us_citation = CitationToken(
-            "410 U. S. 113", 17, 30, "410", "U. S.", "113", [], [us_reporter]
+            "410 U. S. 113",
+            17,
+            30,
+            groups={"volume": "410", "reporter": "U. S.", "page": "113"},
+            variation_editions=(us_reporter,),
         )
         see_token = StopWordToken("See", 0, 3, "see")
         v_token = StopWordToken("v.", 8, 10, "v")
@@ -62,7 +67,9 @@ class TokenizerTest(TestCase):
     def test_overlapping_regexes(self):
         # Make sure we find both "see" and "id." tokens even though their
         # full regexes overlap
-        stop_token = StopWordToken(data="see", start=0, end=3, stop_word="see")
+        stop_token = StopWordToken(
+            data="see", start=0, end=3, groups={"stop_word": "see"}
+        )
         id_token = IdToken(data="id.", start=4, end=7)
         self.assertEqual(
             default_tokenizer.tokenize("see id. at 577."),
@@ -86,7 +93,7 @@ class TokenizerTest(TestCase):
         # text should only require four extractors --
         # stop token, US long cite, US short cite, id.
         expected_strings = {
-            tuple(StopWordToken.stop_tokens),
+            STOP_WORDS,
             ("U.S.",),
             ("U.S.",),
             ("id.", "ibid."),

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -1,9 +1,6 @@
 from unittest import TestCase
 
-import exrex
-import roman
-
-from eyecite.utils import ROMAN_NUMERAL_REGEX, clean_text
+from eyecite.utils import clean_text
 
 
 class UtilsTest(TestCase):
@@ -33,18 +30,3 @@ class UtilsTest(TestCase):
     def test_clean_text_invalid(self):
         with self.assertRaises(ValueError):
             clean_text("foo", ["invalid"])
-
-    def test_roman_numeral_regex(self):
-        """Make sure ROMAN_NUMERAL_REGEX matches all numbers between 1-199
-        except 5, 50, 100."""
-        expected = (
-            list(range(1, 5))
-            + list(range(6, 50))
-            + list(range(51, 100))
-            + list(range(101, 200))
-        )
-        actual = sorted(
-            roman.fromRoman(n.upper())
-            for n in exrex.generate(ROMAN_NUMERAL_REGEX)
-        )
-        self.assertEqual(actual, expected)


### PR DESCRIPTION
This adds extraction of laws.json and journals.json patterns from reporters_db:

```
>>> get_citations("1 U.S. 1. Mass. Gen. Laws ch. 1, § 2. 1 Minn. L. Rev. 2.")
[FullCaseCitation('1 U.S. 1', groups={'volume': '1', 'reporter': 'U.S.', 'page': '1'}),
 LawCitation('Mass. Gen. Laws ch. 1, § 2', groups={'reporter': 'Mass. Gen. Laws', 'chapter': '1', 'section': '2'}),
 JournalCitation('1 Minn. L. Rev. 2', groups={'volume': '1', 'reporter': 'Minn. L. Rev.', 'page': '2'})]
```

Yay! Now some questions ...

**Question: class hierarchy?**

Here's the class hierarchy I currently have for citations, with the ones we actually instantiate in bold:

* CitationBase
  * ResourceCitation: stuff done by full and short cites that matched a pattern from reporters_db
    * FullCitation: label for things that are full cites instead of short cites
      * **FullLawCitation**
      * **FullJournalCitation**
    * CaseCitation: stuff done by case citations
      * **ShortCaseCitation**
    * **FullCaseCitation** (inherits from both CaseCitation and FullCitation)
  * **SupraCitation**
  * **IdCitation**
  * **NonopinionCitation**

You can see it gets kind of messy because we need a base class for things that all reporters_db citations do, a base class for full citations, and a base class for case citations, and then the actual models inherit from one or more of those. Dunno if this could be better.

You can also see I'm not currently attempting to deal with short journal or law citations. Seemed like I could get away with saving that for later.

**Question: citation object attributes?**

OK so once you call `get_citations()` and get back some citations, what (public) attributes and methods do they have? This has gotten a little messy. Here's the current answer in this PR, ignoring the generic ones like IdCitation and SupraCitation:

* All:
  * matched_text(): the actual text matched by the regex that found this cite
  * span(): the range of characters in the input text that represent this cite
  * groups: the dict of match groups in the regex that found this cite
  * base_citation(): matched_text() with corrected reporter string based on edition_guess
  * formatted(): full citation with corrected reporter string and metadata extracted from nearby text
  * reporter_found: same as self.groups['reporter']
  * reporter: same as self.groups['reporter'], but if `edition_guess` is set then it becomes `edition_guess.short_name`
  * year: extracted from following text
  * pin_cite: extracted from following text
  * parenthetical: extracted from following text
  * all_editions: list of Edition objects for the regex that found this cite
  * exact_editions: subset of all_editions that had this as their primary regex
  * variation_editions: subset of all_editions that had this as a variation
  * edition_guess: single Edition object, if there's only one in exact_editions with a valid year, or if no exact_editions, only one in variation_editions with a valid year
* FullCaseCitation -- same as All plus:
  * volume: same as self.groups['volume']
  * page: same as self.groups['page']
  * canonical_reporter: if `edition_guess` is set, becomes the name of the cluster from reporters.json, like `F.` for the edition `F.2d`
  * plaintiff: extracted from preceding text
  * defendant: extracted from preceding text
  * extra: extracted from following text
  * court: extracted from following text
* ShortCaseCitation -- same as FullCaseCitation plus:
  * antecedent_guess: word immediately before citation
* FullJournalCitation:
  * volume: same as self.groups['volume']
  * page: same as self.groups['page']
* FullLawCitation:
  * month: extracted from following text
  * day: extracted from following text
  * publisher: extracted from following text

Possible changes to make this less messy:

* We could collect all of the "extracted from following text" variables into a dict named something like `metadata` that includes everything we capture before and after the cite. So remove the attributes `publisher, day, month, antecedent_guess, court, extra, defendant, plaintiff, parenthetical, pin_cite` and just have like `metadata["publisher"]`. That could leave less of a "lots of special cases" feeling.
  * (One special case I would keep -- I'd probably put the raw value we find for year as `metadata["year"]`, but still set `year` as an integer year from a valid range like we do now, because that one seems useful).
* Remove `canonical_reporter`? Not sure if this is doing anything useful, but you can get it from `edition_guess.reporter.short_name`.
* Remove `reporter_found` in favor of `groups['reporter']`?
* Remove `volume` and `page` in favor of `groups['volume']` and `groups['page']`?
* Rename reporter `reporter` to something like `def cleaned_reporter(): return self.edition_guess.short_name if self.edition_guess else self.groups['reporter']`?
* Rename base_citation() and formatted() to cleaned_citation() and cleaned_citation_full()?

If we made all of those changes then the API for all reporters_db citations would become this:

* All:
  * matched_text()
  * span()
  * groups
  * metadata
  * cleaned_reporter()
  * cleaned_citation()
  * cleaned_citation_full()
  * year
  * all_editions
  * exact_editions
  * variation_editions
  * edition_guess

Happy to include something along these lines in this PR, but I didn't want to delete a bunch of stuff if it wasn't going in the right direction.

**Other miscellaneous stuff in this PR:**

* Removed `do_defendant` and `do_post_citation` flags from `get_citations` since those seem harmless to always do and required some extra moving parts to support. In the future there could be some flag for not extracting cite metadata in general?
* Added a `format_resolution` helper function to the resolve_citations tests while getting those working, to make it easier to see why two resolutions don't match.
* Moved all regexes and regex-building helpers to regexes.py, as Mike suggested in the last PR.
* To make it easier to view citation objects in the repl, everything inheriting from CitationBase now uses a simplified `__repr__` like `FullCaseCitation("original matched text", groups={...})`. Some citation classes previously had formatted citation builders in their `__repr__` function, which I think was misnamed -- those now live in a `formatted()` method, which I suggested above might want to be called `cleaned_citation_full()`.

**Stuff left undone:**

* Handling short cites for laws and journals.
* Pin cite extraction for laws is probably pretty incomplete. (And I suspect some stuff might want to move between reporters.json and laws.json once we look more at that -- like maybe anything cited by page range wants to be in reporters.json.)
* Docs need some updates once we settle on the api.
* Just fyi "U.S.C" won't be found yet because I haven't added federal statutes yet over in reporters_db.