### PR TITLE
Add dump_citations helper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 The following changes are not yet released, but are code complete:
 
-...
+Features:
+ - Adds `dump_citations()` to inspect extracted citations.
 
 ## Current
 

--- a/README.rst
+++ b/README.rst
@@ -193,6 +193,46 @@ a custom full citation resolution function as follows, using the default resolut
         <Resource object>: [<full cite>, <short cite>],
     }
 
+Dumping Citations
+=================
+
+If you want to see what metadata eyecite is able to extract for each citation, you can use :code:`dump_citations`.
+This is primarily useful for developing eyecite, but may also be useful for exploring what data is available to you::
+
+    In [1]: from eyecite import dump_citations, get_citations
+
+    In [2]: text="Mass. Gen. Laws ch. 1, § 2. Foo v. Bar, 1 U.S. 2, 3-4 (1999). Id. at 3. Foo, supra, at 5."
+
+    In [3]: cites=get_citations(text)
+
+    In [4]: print(dump_citations(get_citations(text), text))
+    FullLawCitation: Mass. Gen. Laws ch. 1, § 2. Foo v. Bar, 1 U.S. 2, 3-4 (1
+      * groups
+        * reporter='Mass. Gen. Laws'
+        * chapter='1'
+        * section='2'
+    FullCaseCitation: Laws ch. 1, § 2. Foo v. Bar, 1 U.S. 2, 3-4 (1999). Id. at 3. Foo, s
+      * groups
+        * volume='1'
+        * reporter='U.S.'
+        * page='2'
+      * metadata
+        * pin_cite='3-4'
+        * year='1999'
+        * court='scotus'
+        * plaintiff='Foo'
+        * defendant='Bar,'
+      * year=1999
+    IdCitation: v. Bar, 1 U.S. 2, 3-4 (1999). Id. at 3. Foo, supra, at 5.
+      * metadata
+        * pin_cite='at 3'
+    SupraCitation: 2, 3-4 (1999). Id. at 3. Foo, supra, at 5.
+      * metadata
+        * antecedent_guess='Foo'
+        * pin_cite='at 5'
+
+In the real terminal, the :code:`span()` of each extracted citation will be highlighted.
+You can use the :code:`context_chars=30` parameter to control how much text is shown before and after.
 
 Tokenizers
 ==========

--- a/eyecite/__init__.py
+++ b/eyecite/__init__.py
@@ -1,6 +1,12 @@
 from .annotate import annotate
 from .find_citations import get_citations
 from .resolve import resolve_citations
-from .utils import clean_text
+from .utils import clean_text, dump_citations
 
-__all__ = ["annotate", "get_citations", "clean_text", "resolve_citations"]
+__all__ = [
+    "annotate",
+    "get_citations",
+    "clean_text",
+    "resolve_citations",
+    "dump_citations",
+]

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -105,6 +105,17 @@ class CitationBase:
         metadata if any."""
         return self.matched_text()
 
+    def dump(self) -> dict:
+        """Return citation data for printing by dump_citations."""
+        return {
+            "groups": self.groups,
+            "metadata": {
+                k: v
+                for k, v in self.metadata.__dict__.items()
+                if v is not None
+            },
+        }
+
     def matched_text(self):
         """Text that identified this citation, such as '1 U.S. 1' or 'Id.'"""
         return str(self.token)
@@ -154,6 +165,13 @@ class ResourceCitation(CitationBase):
     def add_metadata(self, words: "Tokens"):
         """Extract metadata from text before and after citation."""
         self.guess_edition()
+
+    def dump(self) -> dict:
+        """Return citation data for printing by dump_citations."""
+        return {
+            **super().dump(),
+            "year": self.year,
+        }
 
     def corrected_reporter(self):
         """Get official reporter string from edition_guess, if possible."""

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -1,6 +1,9 @@
+import re
+from textwrap import dedent
 from unittest import TestCase
 
-from eyecite.utils import clean_text
+from eyecite import get_citations
+from eyecite.utils import clean_text, dump_citations
 
 
 class UtilsTest(TestCase):
@@ -30,3 +33,26 @@ class UtilsTest(TestCase):
     def test_clean_text_invalid(self):
         with self.assertRaises(ValueError):
             clean_text("foo", ["invalid"])
+
+    def test_dump_citations(self):
+        text = "blah. Foo v. Bar, 1 U.S. 2, 3-4 (1999). blah"
+        cites = get_citations(text)
+        dumped_text = dump_citations(cites, text)
+        dumped_text = re.sub(r"\x1B.*?m", "", dumped_text)  # strip colors
+        expected = dedent(
+            """
+        FullCaseCitation: blah. Foo v. Bar, 1 U.S. 2, 3-4 (1999). blah
+          * groups
+            * volume='1'
+            * reporter='U.S.'
+            * page='2'
+          * metadata
+            * pin_cite='3-4'
+            * year='1999'
+            * court='scotus'
+            * plaintiff='Foo'
+            * defendant='Bar,'
+          * year=1999
+        """
+        )
+        self.assertEqual(dumped_text.strip(), expected.strip())


### PR DESCRIPTION
Not sure if this belongs in the library, but when I was adding journals and statutes I found it useful to dump the results for a bunch of CAP cases and eyeball them to see what looked wrong. That resulted in this helper function `dump_citations(cites, text, context_chars=30)`, which has highlighted output that looks like this:

<img width="613" alt="image" src="https://user-images.githubusercontent.com/376272/118290198-2565d900-b4a4-11eb-9f17-b1639c93921f.png">

This seemed useful enough that I thought I'd throw it in to see if it helps other folks as well -- mostly for us developing the library but maybe also helpful if you're using eyecite for your own purposes.