### PR TITLE
Readme intro & tutorial

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ own MyCaseModel for citations we recognize. We'll fall back on returning
                 return resource
         return resolve_full_citation(cite)
 
-    resolutions = resolve_citations(citations, resolve_fullcase_citation=resolve_cite)
+    resolutions = resolve_citations(citations, resolve_full_citation=resolve_cite)
 
     # resolutions:
     # {
@@ -177,10 +177,9 @@ Getting Citations
 =======
 :code:`get_citations()`, the main executable function, takes several parameters.
 
-1. :code:`do_post_citation` ==> bool; whether additional, post-citation information should be extracted (e.g., the court, year, and/or date range of the citation)
-2. :code:`do_defendant` ==> bool; whether the pre-citation defendant (and possibily plaintiff) reference should be extracted
-3. :code:`disambiguate` ==> bool; whether each citation's (possibly ambiguous) reporter should be resolved to its (unambiguous) form
-4. :code:`tokenizer` ==> Tokenizer; an instance of a Tokenizer object (see "Tokenizers" below)
+1. :code:`remove_ambiguous` ==> bool, default :code:`False`: whether to remove citations
+   that might refer to more than one reporter and can't be narrowed down by date.
+2. :code:`tokenizer` ==> Tokenizer, default :code:`eyecite.tokenizers.default_tokenizer`: an instance of a Tokenizer object (see "Tokenizers" below)
 
 
 Cleaning Input Text

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -11,6 +11,7 @@ from eyecite.models import (
     FullJournalCitation,
     FullLawCitation,
     ParagraphToken,
+    ResourceCitation,
     StopWordToken,
     Token,
     Tokens,
@@ -249,7 +250,7 @@ def disambiguate_reporters(
     return [
         c
         for c in citations
-        if not isinstance(c, CaseCitation) or c.edition_guess
+        if not isinstance(c, ResourceCitation) or c.edition_guess
     ]
 
 

--- a/eyecite/resolve.py
+++ b/eyecite/resolve.py
@@ -116,7 +116,7 @@ def _resolve_id_citation(
 
 def resolve_citations(
     citations: List[CitationBase],
-    resolve_fullcase_citation: Callable[
+    resolve_full_citation: Callable[
         [FullCitation], ResourceType
     ] = resolve_full_citation,
     resolve_shortcase_citation: Callable[
@@ -161,7 +161,7 @@ def resolve_citations(
 
         # If the citation is a full citation, try to resolve it
         if isinstance(citation, FullCitation):
-            resolution = resolve_fullcase_citation(citation)
+            resolution = resolve_full_citation(citation)
             resolved_full_cites[citation] = resolution
 
         # If the citation is a short case citation, try to resolve it


### PR DESCRIPTION
This updates the readme intro/background/quickstart a little bit, including just a little bit of Caselaw Access Project horn tooting so I wouldn't feel left out. :)

This also adds a Tutorial section after Quickstart, walking through a full-featured industrial example of using the library. I thought it would be useful to see why all of the parts exist and how they're supposed to fit together in production.

Rendered rst in case that's easier to read: https://github.com/jcushman/eyecite/tree/quickstart