### PR TITLE
Test cleanup

### DIFF
--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -55,7 +55,7 @@ def case_citation(
     """Convenience function for creating mock CaseCitation objects."""
     metadata = kwargs.setdefault("metadata", {})
     groups = kwargs.setdefault("groups", {})
-    if reporter == "U.S." and not short:
+    if reporter == "U.S.":
         metadata.setdefault("court", "scotus")
     if not source_text:
         source_text = f"{volume} {reporter} {page}"

--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -16,7 +16,7 @@ from eyecite.tokenizers import EDITIONS_LOOKUP
 
 
 def resource_citation(
-    cls, index, source_text, reporter, short=False, year=None, **kwargs
+    cls, source_text, reporter, short=False, year=None, index=0, **kwargs
 ):
     """Create a mock ResourceCitation."""
     metadata = kwargs.pop("metadata", {})
@@ -44,7 +44,6 @@ def resource_citation(
 
 
 def case_citation(
-    index,
     source_text=None,
     page="1",
     reporter="U.S.",
@@ -65,25 +64,19 @@ def case_citation(
         groups.setdefault("volume", volume)
     groups.setdefault("page", page)
     cls = ShortCaseCitation if short else FullCaseCitation
-    return resource_citation(
-        cls, index, source_text, reporter, short, **kwargs
-    )
+    return resource_citation(cls, source_text, reporter, short, **kwargs)
 
 
 def law_citation(
-    index,
     source_text,
     reporter,
     **kwargs,
 ):
     """Convenience function for creating mock FullLawCitation objects."""
-    return resource_citation(
-        FullLawCitation, index, source_text, reporter, **kwargs
-    )
+    return resource_citation(FullLawCitation, source_text, reporter, **kwargs)
 
 
 def journal_citation(
-    index,
     source_text=None,
     page="1",
     reporter="Minn. L. Rev.",
@@ -97,20 +90,22 @@ def journal_citation(
     groups.setdefault("volume", volume)
     groups.setdefault("page", page)
     return resource_citation(
-        FullJournalCitation, index, source_text, reporter, **kwargs
+        FullJournalCitation, source_text, reporter, **kwargs
     )
 
 
-def id_citation(index, source_text=None, **kwargs):
+def id_citation(source_text=None, index=0, **kwargs):
     """Convenience function for creating mock IdCitation objects."""
     return IdCitation(IdToken(source_text, 0, 99), index, **kwargs)
 
 
-def nonopinion_citation(index, source_text=None):
+def nonopinion_citation(source_text=None, index=0, **kwargs):
     """Convenience function for creating mock NonopinionCitation objects."""
-    return NonopinionCitation(SectionToken(source_text, 0, 99), index)
+    return NonopinionCitation(
+        SectionToken(source_text, 0, 99), index, **kwargs
+    )
 
 
-def supra_citation(index, source_text=None, **kwargs):
+def supra_citation(source_text=None, index=0, **kwargs):
     """Convenience function for creating mock SupraCitation objects."""
     return SupraCitation(SupraToken(source_text, 0, 99), index, **kwargs)

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -213,30 +213,25 @@ class FindTest(TestCase):
             # Test first kind of short form citation (meaningless antecedent)
             ('before asdf 1 U. S., at 2',
              [case_citation(2, page='2', reporter_found='U. S.', short=True,
-                            metadata={'antecedent_guess': 'asdf',
-                                      'court': 'scotus'})]),
+                            metadata={'antecedent_guess': 'asdf'})]),
             # Test second kind of short form citation (meaningful antecedent)
             ('before asdf, 1 U. S., at 2',
              [case_citation(2, page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
-                            metadata={'antecedent_guess': 'asdf',
-                                      'court': 'scotus'})]),
+                            metadata={'antecedent_guess': 'asdf'})]),
             # Test short form citation with preceding ASCII quotation
             ('before asdf,” 1 U. S., at 2',
              [case_citation(2, page='2', reporter_found='U. S.',
-                            short=True,
-                            metadata={'court': 'scotus'})]),
+                            short=True)]),
             # Test short form citation when case name looks like a reporter
             ('before Johnson, 1 U. S., at 2',
              [case_citation(2, page='2', reporter_found='U. S.', short=True,
-                            metadata={'antecedent_guess': 'Johnson',
-                                      'court': 'scotus'})]),
+                            metadata={'antecedent_guess': 'Johnson'})]),
             # Test short form citation with no comma after reporter
             ('before asdf, 1 U. S. at 2',
              [case_citation(2, page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
-                            metadata={'antecedent_guess': 'asdf',
-                                      'court': 'scotus'})]),
+                            metadata={'antecedent_guess': 'asdf'})]),
             # Test short form citation at end of document (issue #1171)
             ('before asdf, 1 U. S. end', []),
             # Test supra citation across line break
@@ -249,44 +244,38 @@ class FindTest(TestCase):
             ('before asdf, 1 U. S., at 20-25',
              [case_citation(2, page='20', reporter_found='U. S.', short=True,
                             metadata={'pin_cite': '20-25',
-                                      'antecedent_guess': 'asdf',
-                                      'court': 'scotus'})]),
+                                      'antecedent_guess': 'asdf'})]),
             # Test short form citation with a page range with weird suffix
             ('before asdf, 1 U. S., at 20-25\\& n. 4',
              [case_citation(2, page='20', reporter_found='U. S.', short=True,
                             metadata={'pin_cite': '20-25',
-                                      'antecedent_guess': 'asdf',
-                                      'court': 'scotus'})]),
+                                      'antecedent_guess': 'asdf'})]),
             # Test short form citation with a parenthetical
             ('before asdf, 1 U. S., at 2 (overruling xyz)',
              [case_citation(4, page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
-                                      'parenthetical': 'overruling xyz',
-                                      'court': 'scotus'}
+                                      'parenthetical': 'overruling xyz'}
                             )]),
             # Test short form citation with no space before parenthetical
             ('before asdf, 1 U. S., at 2(overruling xyz)',
              [case_citation(4, page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
-                                      'parenthetical': 'overruling xyz',
-                                      'court': 'scotus'}
+                                      'parenthetical': 'overruling xyz'}
                             )]),
             # Test short form citation with nested parentheticals
             ('before asdf, 1 U. S., at 2 (discussing xyz (Holmes, J., concurring))',
              [case_citation(4, page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
-                                      'parenthetical': 'discussing xyz (Holmes, J., concurring)',
-                                      'court': 'scotus'}
+                                      'parenthetical': 'discussing xyz (Holmes, J., concurring)'}
                             )]),
             # Test that short form citation doesn't treat year as parenthetical
             ('before asdf, 1 U. S., at 2 (2016)',
              [case_citation(4, page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
-                            metadata={'antecedent_guess': 'asdf',
-                                      'court': 'scotus'}
+                            metadata={'antecedent_guess': 'asdf'}
                             )]),
             # Test short form citation with page range and parenthetical
             ('before asdf, 1 U. S., at 20-25 (overruling xyz)',
@@ -294,15 +283,13 @@ class FindTest(TestCase):
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
                                       'pin_cite': '20-25',
-                                      'parenthetical': 'overruling xyz',
-                                      'court': 'scotus'}
+                                      'parenthetical': 'overruling xyz'}
                             )]),
             # Test short form citation with subsequent unrelated parenthetical
             ('asdf, 1 U. S., at 4 (discussing abc). Some other nonsense (clarifying nonsense)',
              [case_citation(2, page='4', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
-                                      'court': 'scotus',
                                       'parenthetical': 'discussing abc'}
                             )]
              ),
@@ -311,16 +298,12 @@ class FindTest(TestCase):
              [case_citation(0, page='2', reporter='U.S.',
                             reporter_found='U. S.',
                             short=True, volume='1',
-                            metadata={'pin_cite': '2',
-                                      'court': 'scotus'}
-                            ),
+                            metadata={'pin_cite': '2'}),
               case_citation(9, page='4', reporter='U.S.',
                             reporter_found='U. S.', short=False,
                             year=2010, volume='3',
                             metadata={'parenthetical': 'overruling xyz',
-                                      'plaintiff': 'foo', 'defendant': 'bar',
-                                      'court': 'scotus'}
-                            )
+                                      'plaintiff': 'foo', 'defendant': 'bar'})
               ]),
             # Test with multiple citations and parentheticals
             ('1 U. S., at 2 (criticizing xyz). foo v. bar 3 U. S. 4 (2010) (overruling xyz).',
@@ -328,16 +311,12 @@ class FindTest(TestCase):
                             reporter_found='U. S.',
                             short=True, volume='1',
                             metadata={'pin_cite': '2',
-                                      'court': 'scotus',
-                                      'parenthetical': 'criticizing xyz'}
-                            ),
+                                      'parenthetical': 'criticizing xyz'}),
               case_citation(12, page='4', reporter='U.S.',
                             reporter_found='U. S.', short=False,
                             year=2010, volume='3',
                             metadata={'parenthetical': 'overruling xyz',
-                                      'plaintiff': 'foo', 'defendant': 'bar',
-                                      'court': 'scotus'}
-                            )
+                                      'plaintiff': 'foo', 'defendant': 'bar'})
               ]),
             # Test first kind of supra citation (standard kind)
             ('before asdf, supra, at 2',
@@ -468,10 +447,8 @@ class FindTest(TestCase):
             # Token scanning edge case -- missing plaintiff name at start of input
             ('v. Bar, 1 U.S. 1', [case_citation(0, metadata={'defendant': 'Bar'})]),
             # Token scanning edge case -- short form start of input
-            ('1 U.S., at 1', [case_citation(0, short=True,
-                                            metadata={'court': 'scotus'})]),
-            (', 1 U.S., at 1', [case_citation(0, short=True,
-                                              metadata={'court': 'scotus'})]),
+            ('1 U.S., at 1', [case_citation(0, short=True)]),
+            (', 1 U.S., at 1', [case_citation(0, short=True)]),
             # Token scanning edge case -- supra at start of input
             ('supra.', [supra_citation(0, "supra.")]),
             (', supra.', [supra_citation(0, "supra.")]),

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -38,9 +38,6 @@ class FindTest(TestCase):
     def run_test_pairs(self, test_pairs, message, tokenizers=None):
         def get_comparison_attrs(cite):
             out = {
-                # Indexes are all incorrect/broken at the moment, commenting this
-                # until fixed so that other functionality can be verified by CI.
-                # "index": cite.index,
                 "groups": cite.groups,
                 "metadata": cite.metadata,
             }
@@ -93,58 +90,58 @@ class FindTest(TestCase):
         test_pairs = (
             # Basic test
             ('1 U.S. 1',
-             [case_citation(0)]),
+             [case_citation()]),
             # Basic test with a line break
             ('1 U.S.\n1',
-             [case_citation(0)],
+             [case_citation()],
              {'clean': ['all_whitespace']}),
             # Basic test with a line break within a reporter
             ('1 U.\nS. 1',
-             [case_citation(0, reporter_found='U. S.')],
+             [case_citation(reporter_found='U. S.')],
              {'clean': ['all_whitespace']}),
             # Basic test of non-case name before citation (should not be found)
             ('lissner test 1 U.S. 1',
-             [case_citation(2)]),
+             [case_citation()]),
             # Test with plaintiff and defendant
             ('lissner v. test 1 U.S. 1',
-             [case_citation(3, metadata={'plaintiff': 'lissner',
-                                         'defendant': 'test'})]),
+             [case_citation(metadata={'plaintiff': 'lissner',
+                                      'defendant': 'test'})]),
             # Test with plaintiff, defendant and year
             ('lissner v. test 1 U.S. 1 (1982)',
-             [case_citation(3, metadata={'plaintiff': 'lissner',
-                                         'defendant': 'test'},
+             [case_citation(metadata={'plaintiff': 'lissner',
+                                      'defendant': 'test'},
                             year=1982)]),
             # Don't choke on misformatted year
             ('lissner v. test 1 U.S. 1 (198⁴)',
-             [case_citation(3, metadata={'plaintiff': 'lissner',
-                                         'defendant': 'test'})]),
+             [case_citation(metadata={'plaintiff': 'lissner',
+                                      'defendant': 'test'})]),
             # Test with different reporter than all of above.
             ('bob lissner v. test 1 F.2d 1 (1982)',
-             [case_citation(4, reporter='F.2d', year=1982,
+             [case_citation(reporter='F.2d', year=1982,
                             metadata={'plaintiff': 'lissner',
                                       'defendant': 'test'})]),
             # Test with comma after defendant's name
             ('lissner v. test, 1 U.S. 1 (1982)',
-             [case_citation(3, metadata={'plaintiff': 'lissner',
-                                         'defendant': 'test'},
+             [case_citation(metadata={'plaintiff': 'lissner',
+                                      'defendant': 'test'},
                             year=1982)]),
             # Test with court and extra information
             ('bob lissner v. test 1 U.S. 12, 347-348 (4th Cir. 1982)',
-             [case_citation(4, page='12', year=1982,
+             [case_citation(page='12', year=1982,
                             metadata={'plaintiff': 'lissner',
                                       'defendant': 'test',
                                       'court': 'ca4',
                                       'pin_cite': '347-348'})]),
             # Parallel cite with parenthetical
             ('bob lissner v. test 1 U.S. 12, 347-348, 1 S. Ct. 2, 358 (4th Cir. 1982) (overruling foo)',
-             [case_citation(4, page='12', year=1982,
+             [case_citation(page='12', year=1982,
                             metadata={'plaintiff': 'lissner',
                                       'defendant': 'test',
                                       'court': 'ca4',
                                       'pin_cite': '347-348',
                                       'extra': "1 S. Ct. 2, 358",
                                       'parenthetical': 'overruling foo'}),
-              case_citation(4, page='2', reporter='S. Ct.', year=1982,
+              case_citation(page='2', reporter='S. Ct.', year=1982,
                             metadata={'plaintiff': 'lissner',
                                       'defendant': 'test 1 U.S. 12, 347-348',
                                       'court': 'ca4',
@@ -153,133 +150,133 @@ class FindTest(TestCase):
               ]),
             # Test full citation with nested parenthetical
             ('lissner v. test 1 U.S. 1 (1982) (discussing abc (Holmes, J., concurring))',
-             [case_citation(6, metadata={'plaintiff': 'lissner',
-                                         'defendant': 'test',
-                                         'parenthetical': 'discussing abc (Holmes, J., concurring)'},
+             [case_citation(metadata={'plaintiff': 'lissner',
+                                      'defendant': 'test',
+                                      'parenthetical': 'discussing abc (Holmes, J., concurring)'},
                             year=1982)]),
             # Test full citation with parenthetical and subsequent unrelated parenthetical
             ('lissner v. test 1 U.S. 1 (1982) (discussing abc); blah (something).',
-             [case_citation(6, metadata={'plaintiff': 'lissner',
-                                         'defendant': 'test',
-                                         'parenthetical': 'discussing abc'},
+             [case_citation(metadata={'plaintiff': 'lissner',
+                                      'defendant': 'test',
+                                      'parenthetical': 'discussing abc'},
                             year=1982)]),
             # Test with text before and after and a variant reporter
             ('asfd 22 U. S. 332 (1975) asdf',
-             [case_citation(1, page='332', volume='22',
+             [case_citation(page='332', volume='22',
                             reporter_found='U. S.', year=1975)]),
             # Test with finding reporter when it's a second edition
             ('asdf 22 A.2d 332 asdf',
-             [case_citation(1, page='332', reporter='A.2d', volume='22')]),
+             [case_citation(page='332', reporter='A.2d', volume='22')]),
             # Test if reporter in string will find proper citation string
             ('A.2d 332 11 A.2d 333',
-             [case_citation(2, page='333', reporter='A.2d', volume='11')]),
+             [case_citation(page='333', reporter='A.2d', volume='11')]),
             # Test finding a variant second edition reporter
             ('asdf 22 A. 2d 332 asdf',
-             [case_citation(1, page='332', reporter='A.2d', volume='22',
+             [case_citation(page='332', reporter='A.2d', volume='22',
                             reporter_found='A. 2d')]),
             # Test finding a variant of an edition resolvable by variant alone.
             ('171 Wn.2d 1016',
-             [case_citation(0, page='1016', reporter='Wash. 2d', volume='171',
+             [case_citation(page='1016', reporter='Wash. 2d', volume='171',
                             reporter_found='Wn.2d')]),
             # Test finding two citations where one of them has abutting
             # punctuation.
             ('2 U.S. 3, 4-5 (3 Atl. 33)',
-             [case_citation(0, page='3', volume='2', metadata={'pin_cite': '4-5'}),
-              case_citation(3, page='33', reporter="A.", volume='3',
+             [case_citation(page='3', volume='2', metadata={'pin_cite': '4-5'}),
+              case_citation(page='33', reporter="A.", volume='3',
                             reporter_found="Atl.")]),
             # Test with the page number as a Roman numeral
             ('12 Neb. App. lxiv (2004)',
-             [case_citation(0, page='lxiv', reporter='Neb. Ct. App.',
+             [case_citation(page='lxiv', reporter='Neb. Ct. App.',
                             volume='12',
                             reporter_found='Neb. App.', year=2004)]),
             # Test with page range with a weird suffix
             ('559 N.W.2d 826|N.D.',
-             [case_citation(0, page='826', reporter='N.W.2d', volume='559')]),
+             [case_citation(page='826', reporter='N.W.2d', volume='559')]),
             # Test with malformed/missing page number
             ('1 U.S. f24601', []),
             # Test with the 'digit-REPORTER-digit' corner-case formatting
             ('2007-NMCERT-008',
-             [case_citation(0, source_text='2007-NMCERT-008', page='008',
+             [case_citation(source_text='2007-NMCERT-008', page='008',
                             reporter='NMCERT', volume='2007')]),
             ('2006-Ohio-2095',
-             [case_citation(0, source_text='2006-Ohio-2095', page='2095',
+             [case_citation(source_text='2006-Ohio-2095', page='2095',
                             reporter='Ohio', volume='2006')]),
             ('2017 IL App (4th) 160407',
-             [case_citation(0, page='160407', reporter='IL App (4th)',
+             [case_citation(page='160407', reporter='IL App (4th)',
                             volume='2017')]),
             ('2017 IL App (1st) 143684-B',
-             [case_citation(0, page='143684-B', reporter='IL App (1st)',
+             [case_citation(page='143684-B', reporter='IL App (1st)',
                             volume='2017')]),
             # Test first kind of short form citation (meaningless antecedent)
             ('before asdf 1 U. S., at 2',
-             [case_citation(2, page='2', reporter_found='U. S.', short=True,
+             [case_citation(page='2', reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf'})]),
             # Test second kind of short form citation (meaningful antecedent)
             ('before asdf, 1 U. S., at 2',
-             [case_citation(2, page='2', reporter='U.S.',
+             [case_citation(page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf'})]),
             # Test short form citation with preceding ASCII quotation
             ('before asdf,” 1 U. S., at 2',
-             [case_citation(2, page='2', reporter_found='U. S.',
+             [case_citation(page='2', reporter_found='U. S.',
                             short=True)]),
             # Test short form citation when case name looks like a reporter
             ('before Johnson, 1 U. S., at 2',
-             [case_citation(2, page='2', reporter_found='U. S.', short=True,
+             [case_citation(page='2', reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'Johnson'})]),
             # Test short form citation with no comma after reporter
             ('before asdf, 1 U. S. at 2',
-             [case_citation(2, page='2', reporter='U.S.',
+             [case_citation(page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf'})]),
             # Test short form citation at end of document (issue #1171)
             ('before asdf, 1 U. S. end', []),
             # Test supra citation across line break
             ('before asdf, supra,\nat 2',
-             [supra_citation(2, "supra,",
+             [supra_citation("supra,",
                              metadata={'pin_cite': 'at 2',
                                        'antecedent_guess': 'asdf'})],
              {'clean': ['all_whitespace']}),
             # Test short form citation with a page range
             ('before asdf, 1 U. S., at 20-25',
-             [case_citation(2, page='20', reporter_found='U. S.', short=True,
+             [case_citation(page='20', reporter_found='U. S.', short=True,
                             metadata={'pin_cite': '20-25',
                                       'antecedent_guess': 'asdf'})]),
             # Test short form citation with a page range with weird suffix
             ('before asdf, 1 U. S., at 20-25\\& n. 4',
-             [case_citation(2, page='20', reporter_found='U. S.', short=True,
+             [case_citation(page='20', reporter_found='U. S.', short=True,
                             metadata={'pin_cite': '20-25',
                                       'antecedent_guess': 'asdf'})]),
             # Test short form citation with a parenthetical
             ('before asdf, 1 U. S., at 2 (overruling xyz)',
-             [case_citation(4, page='2', reporter='U.S.',
+             [case_citation(page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
                                       'parenthetical': 'overruling xyz'}
                             )]),
             # Test short form citation with no space before parenthetical
             ('before asdf, 1 U. S., at 2(overruling xyz)',
-             [case_citation(4, page='2', reporter='U.S.',
+             [case_citation(page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
                                       'parenthetical': 'overruling xyz'}
                             )]),
             # Test short form citation with nested parentheticals
             ('before asdf, 1 U. S., at 2 (discussing xyz (Holmes, J., concurring))',
-             [case_citation(4, page='2', reporter='U.S.',
+             [case_citation(page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
                                       'parenthetical': 'discussing xyz (Holmes, J., concurring)'}
                             )]),
             # Test that short form citation doesn't treat year as parenthetical
             ('before asdf, 1 U. S., at 2 (2016)',
-             [case_citation(4, page='2', reporter='U.S.',
+             [case_citation(page='2', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf'}
                             )]),
             # Test short form citation with page range and parenthetical
             ('before asdf, 1 U. S., at 20-25 (overruling xyz)',
-             [case_citation(4, page='20', reporter='U.S.',
+             [case_citation(page='20', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
                                       'pin_cite': '20-25',
@@ -287,7 +284,7 @@ class FindTest(TestCase):
                             )]),
             # Test short form citation with subsequent unrelated parenthetical
             ('asdf, 1 U. S., at 4 (discussing abc). Some other nonsense (clarifying nonsense)',
-             [case_citation(2, page='4', reporter='U.S.',
+             [case_citation(page='4', reporter='U.S.',
                             reporter_found='U. S.', short=True,
                             metadata={'antecedent_guess': 'asdf',
                                       'parenthetical': 'discussing abc'}
@@ -295,11 +292,11 @@ class FindTest(TestCase):
              ),
             # Test parenthetical matching with multiple citations
             ('1 U. S., at 2. foo v. bar 3 U. S. 4 (2010) (overruling xyz).',
-             [case_citation(0, page='2', reporter='U.S.',
+             [case_citation(page='2', reporter='U.S.',
                             reporter_found='U. S.',
                             short=True, volume='1',
                             metadata={'pin_cite': '2'}),
-              case_citation(9, page='4', reporter='U.S.',
+              case_citation(page='4', reporter='U.S.',
                             reporter_found='U. S.', short=False,
                             year=2010, volume='3',
                             metadata={'parenthetical': 'overruling xyz',
@@ -307,12 +304,12 @@ class FindTest(TestCase):
               ]),
             # Test with multiple citations and parentheticals
             ('1 U. S., at 2 (criticizing xyz). foo v. bar 3 U. S. 4 (2010) (overruling xyz).',
-             [case_citation(0, page='2', reporter='U.S.',
+             [case_citation(page='2', reporter='U.S.',
                             reporter_found='U. S.',
                             short=True, volume='1',
                             metadata={'pin_cite': '2',
                                       'parenthetical': 'criticizing xyz'}),
-              case_citation(12, page='4', reporter='U.S.',
+              case_citation(page='4', reporter='U.S.',
                             reporter_found='U. S.', short=False,
                             year=2010, volume='3',
                             metadata={'parenthetical': 'overruling xyz',
@@ -320,108 +317,108 @@ class FindTest(TestCase):
               ]),
             # Test first kind of supra citation (standard kind)
             ('before asdf, supra, at 2',
-             [supra_citation(2, "supra,",
+             [supra_citation("supra,",
                              metadata={'pin_cite': 'at 2',
                                        'antecedent_guess': 'asdf'})]),
             # Test second kind of supra citation (with volume)
             ('before asdf, 123 supra, at 2',
-             [supra_citation(3, "supra,",
+             [supra_citation("supra,",
                              metadata={'pin_cite': 'at 2',
                                        'volume': '123',
                                        'antecedent_guess': 'asdf'})]),
             # Test third kind of supra citation (sans page)
             ('before asdf, supra, foo bar',
-             [supra_citation(2, "supra,",
+             [supra_citation("supra,",
                              metadata={'antecedent_guess': 'asdf'})]),
             # Test third kind of supra citation (with period)
             ('before asdf, supra. foo bar',
-             [supra_citation(2, "supra,",
+             [supra_citation("supra,",
                              metadata={'antecedent_guess': 'asdf'})]),
             # Test supra citation at end of document (issue #1171)
             ('before asdf, supra end',
-             [supra_citation(2, "supra,",
+             [supra_citation("supra,",
                              metadata={'antecedent_guess': 'asdf'})]),
             # Test Ibid. citation
             ('foo v. bar 1 U.S. 12. asdf. Ibid. foo bar lorem ipsum.',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar'}),
-              id_citation(7, 'Ibid.')]),
+              id_citation('Ibid.')]),
             # Test italicized Ibid. citation
             ('<p>before asdf. <i>Ibid.</i></p> <p>foo bar lorem</p>',
-             [id_citation(2, 'Ibid.')],
+             [id_citation('Ibid.')],
              {'clean': ['html', 'inline_whitespace']}),
             # Test Id. citation
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id., at 123. foo bar',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
-              id_citation(8, 'Id.,',
+              id_citation('Id.,',
                           metadata={'pin_cite': 'at 123'})]),
             # Test Id. citation across line break
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id.,\nat 123. foo bar',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
-              id_citation(8, 'Id.,', metadata={'pin_cite': 'at 123'})],
+              id_citation('Id.,', metadata={'pin_cite': 'at 123'})],
              {'clean': ['all_whitespace']}),
             # Test italicized Id. citation
             ('<p>before asdf. <i>Id.,</i> at 123.</p> <p>foo bar</p>',
-             [id_citation(2, 'Id.,', metadata={'pin_cite': 'at 123'})],
+             [id_citation('Id.,', metadata={'pin_cite': 'at 123'})],
              {'clean': ['html', 'inline_whitespace']}),
             # Test italicized Id. citation with another HTML tag in the way
             ('<p>before asdf. <i>Id.,</i> at <b>123.</b></p> <p>foo bar</p>',
-             [id_citation(2, 'Id.,', metadata={'pin_cite': 'at 123'})],
+             [id_citation('Id.,', metadata={'pin_cite': 'at 123'})],
              {'clean': ['html', 'inline_whitespace']}),
             # Test weirder Id. citations (#1344)
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. ¶ 34. foo bar',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
-              id_citation(8, 'Id.', metadata={'pin_cite': '¶ 34'})]),
+              id_citation('Id.', metadata={'pin_cite': '¶ 34'})]),
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. at 62-63, 67-68. f b',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
-              id_citation(8, 'Id.', metadata={'pin_cite': 'at 62-63, 67-68'})]),
+              id_citation('Id.', metadata={'pin_cite': 'at 62-63, 67-68'})]),
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id., at *10. foo bar',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
-              id_citation(8, 'Id.,', metadata={'pin_cite': 'at *10'})]),
+              id_citation('Id.,', metadata={'pin_cite': 'at *10'})]),
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. at 7-9, ¶¶ 38-53. f b',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
-              id_citation(8, 'Id.', metadata={'pin_cite': 'at 7-9, ¶¶ 38-53'})]),
+              id_citation('Id.', metadata={'pin_cite': 'at 7-9, ¶¶ 38-53'})]),
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. at pp. 45, 64. foo bar',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
-              id_citation(8, 'Id.', metadata={'pin_cite': 'at pp. 45, 64'})]),
+              id_citation('Id.', metadata={'pin_cite': 'at pp. 45, 64'})]),
             ('foo v. bar 1 U.S. 12, 347-348. asdf. id. 119:12-14. foo bar',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
-              id_citation(8, 'id.', metadata={'pin_cite': '119:12-14'})]),
+              id_citation('id.', metadata={'pin_cite': '119:12-14'})]),
             # Test Id. citation without page number
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. No page number.',
-             [case_citation(3, page='12',
+             [case_citation(page='12',
                             metadata={'plaintiff': 'foo',
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
-              id_citation(8, 'Id.')]),
+              id_citation('Id.')]),
             # Test non-opinion citation
             ('lorem ipsum see §99 of the U.S. code.',
-             [nonopinion_citation(3, '§99')]),
+             [nonopinion_citation('§99')]),
             # Test address that's not a citation (#1338)
             ('lorem 111 S.W. 12th St.',
              [],),
@@ -429,34 +426,34 @@ class FindTest(TestCase):
              [],),
             # Test Conn. Super. Ct. regex variation.
             ('Failed to recognize 1993 Conn. Super. Ct. 5243-P',
-             [case_citation(3, volume='1993', reporter='Conn. Super. Ct.',
+             [case_citation(volume='1993', reporter='Conn. Super. Ct.',
                             page='5243-P')]),
             # Test that the tokenizer handles commas after a reporter. In the
             # past, " U. S. " would match but not " U. S., "
             ('foo 1 U.S., 1 bar',
-             [case_citation(0)]),
+             [case_citation()]),
             # Test reporter with custom regex
             ('blah blah Bankr. L. Rep. (CCH) P12,345. blah blah',
-             [case_citation(2, volume='', reporter='Bankr. L. Rep.',
+             [case_citation(volume='', reporter='Bankr. L. Rep.',
                             reporter_found='Bankr. L. Rep. (CCH)', page='12,345')]),
             ('blah blah, 2009 12345 (La.App. 1 Cir. 05/10/10). blah blah',
-             [case_citation(2, volume='2009', reporter='La.App. 1 Cir.',
+             [case_citation(volume='2009', reporter='La.App. 1 Cir.',
                             page='12345', groups={'date_filed': '05/10/10'})]),
             # Token scanning edge case -- incomplete paren at end of input
-            ('1 U.S. 1 (', [case_citation(0)]),
+            ('1 U.S. 1 (', [case_citation()]),
             # Token scanning edge case -- missing plaintiff name at start of input
-            ('v. Bar, 1 U.S. 1', [case_citation(0, metadata={'defendant': 'Bar'})]),
+            ('v. Bar, 1 U.S. 1', [case_citation(metadata={'defendant': 'Bar'})]),
             # Token scanning edge case -- short form start of input
-            ('1 U.S., at 1', [case_citation(0, short=True)]),
-            (', 1 U.S., at 1', [case_citation(0, short=True)]),
+            ('1 U.S., at 1', [case_citation(short=True)]),
+            (', 1 U.S., at 1', [case_citation(short=True)]),
             # Token scanning edge case -- supra at start of input
-            ('supra.', [supra_citation(0, "supra.")]),
-            (', supra.', [supra_citation(0, "supra.")]),
-            ('123 supra.', [supra_citation(0, "supra.", metadata={'volume': "123"})]),
+            ('supra.', [supra_citation("supra.")]),
+            (', supra.', [supra_citation("supra.")]),
+            ('123 supra.', [supra_citation("supra.", metadata={'volume': "123"})]),
             # Token scanning edge case -- Id. at end of input
-            ('Id.', [id_citation(0, 'Id.,')]),
-            ('Id. at 1.', [id_citation(0, 'Id.,', metadata={'pin_cite': 'at 1'})]),
-            ('Id. foo', [id_citation(0, 'Id.,')]),
+            ('Id.', [id_citation('Id.,')]),
+            ('Id. at 1.', [id_citation('Id.,', metadata={'pin_cite': 'at 1'})]),
+            ('Id. foo', [id_citation('Id.,')]),
             # Reject citations that are part of larger words
             ('foo1 U.S. 1, 1. U.S. 1foo', [],),
         )
@@ -475,60 +472,60 @@ class FindTest(TestCase):
         test_pairs = (
             # Basic test
             ('Mass. Gen. Laws ch. 1, § 2',
-             [law_citation(0, 'Mass. Gen. Laws ch. 1, § 2',
+             [law_citation('Mass. Gen. Laws ch. 1, § 2',
                            reporter='Mass. Gen. Laws',
                            groups={'chapter': '1', 'section': '2'})]),
             ('1 Stat. 2',
-             [law_citation(0, '1 Stat. 2',
+             [law_citation('1 Stat. 2',
                            reporter='Stat.',
                            groups={'volume': '1', 'page': '2'})]),
             # year
             ('Fla. Stat. § 120.68 (2007)',
-             [law_citation(0, 'Fla. Stat. § 120.68 (2007)',
+             [law_citation('Fla. Stat. § 120.68 (2007)',
                            reporter='Fla. Stat.', year=2007,
                            groups={'section': '120.68'})]),
             # et seq, publisher, year
             ('Ariz. Rev. Stat. Ann. § 36-3701 et seq. (West 2009)',
-             [law_citation(0, 'Ariz. Rev. Stat. Ann. § 36-3701 et seq. (West 2009)',
+             [law_citation('Ariz. Rev. Stat. Ann. § 36-3701 et seq. (West 2009)',
                            reporter='Ariz. Rev. Stat. Ann.',
                            metadata={'pin_cite': 'et seq.', 'publisher': 'West'},
                            groups={'section': '36-3701'},
                            year=2009)]),
             # multiple sections
             ('Mass. Gen. Laws ch. 1, §§ 2-3',
-             [law_citation(0, 'Mass. Gen. Laws ch. 1, §§ 2-3',
+             [law_citation('Mass. Gen. Laws ch. 1, §§ 2-3',
                            reporter='Mass. Gen. Laws',
                            groups={'chapter': '1', 'section': '2-3'})]),
             # parenthetical
             ('Kan. Stat. Ann. § 21-3516(a)(2) (repealed)',
-             [law_citation(0, 'Kan. Stat. Ann. § 21-3516(a)(2) (repealed)',
+             [law_citation('Kan. Stat. Ann. § 21-3516(a)(2) (repealed)',
                            reporter='Kan. Stat. Ann.',
                            metadata={'pin_cite': '(a)(2)', 'parenthetical': 'repealed'},
                            groups={'section': '21-3516'})]),
             # Supp. publisher
             ('Ohio Rev. Code Ann. § 5739.02(B)(7) (Lexis Supp. 2010)',
-             [law_citation(0, 'Ohio Rev. Code Ann. § 5739.02(B)(7) (Lexis Supp. 2010)',
+             [law_citation('Ohio Rev. Code Ann. § 5739.02(B)(7) (Lexis Supp. 2010)',
                            reporter='Ohio Rev. Code Ann.',
                            metadata={'pin_cite': '(B)(7)', 'publisher': 'Lexis Supp.'},
                            groups={'section': '5739.02'},
                            year=2010)]),
             # Year range
             ('Wis. Stat. § 655.002(2)(c) (2005-06)',
-             [law_citation(0, 'Wis. Stat. § 655.002(2)(c) (2005-06)',
+             [law_citation('Wis. Stat. § 655.002(2)(c) (2005-06)',
                            reporter='Wis. Stat.',
                            metadata={'pin_cite': '(2)(c)'},
                            groups={'section': '655.002'},
                            year=2005)]),
             # 'and' pin cite
             ('Ark. Code Ann. § 23-3-119(a)(2) and (d) (1987)',
-             [law_citation(0, 'Ark. Code Ann. § 23-3-119(a)(2) and (d) (1987)',
+             [law_citation('Ark. Code Ann. § 23-3-119(a)(2) and (d) (1987)',
                            reporter='Ark. Code Ann.',
                            metadata={'pin_cite': '(a)(2) and (d)'},
                            groups={'section': '23-3-119'},
                            year=1987)]),
             # Cite to multiple sections
             ('Mass. Gen. Laws ch. 1, §§ 2-3',
-             [law_citation(0, 'Mass. Gen. Laws ch. 1, §§ 2-3',
+             [law_citation('Mass. Gen. Laws ch. 1, §§ 2-3',
                            reporter='Mass. Gen. Laws',
                            groups={'chapter': '1', 'section': '2-3'})]),
         )
@@ -541,23 +538,23 @@ class FindTest(TestCase):
         test_pairs = (
             # Basic test
             ('1 Minn. L. Rev. 1',
-             [journal_citation(0)]),
+             [journal_citation()]),
             # Pin cite
             ('1 Minn. L. Rev. 1, 2-3',
-             [journal_citation(0, metadata={'pin_cite': '2-3'})]),
+             [journal_citation(metadata={'pin_cite': '2-3'})]),
             # Year
             ('1 Minn. L. Rev. 1 (2007)',
-             [journal_citation(0, year=2007)]),
+             [journal_citation(year=2007)]),
             # Pin cite and year
             ('1 Minn. L. Rev. 1, 2-3 (2007)',
-             [journal_citation(0, metadata={'pin_cite': '2-3'}, year=2007)]),
+             [journal_citation(metadata={'pin_cite': '2-3'}, year=2007)]),
             # Pin cite and year and parenthetical
             ('1 Minn. L. Rev. 1, 2-3 (2007) (discussing ...)',
-             [journal_citation(0, year=2007,
+             [journal_citation(year=2007,
                                metadata={'pin_cite': '2-3', 'parenthetical': 'discussing ...'})]),
             # Year range
             ('77 Marq. L. Rev. 475 (1993-94)',
-             [journal_citation(0, volume='77', reporter='Marq. L. Rev.',
+             [journal_citation(volume='77', reporter='Marq. L. Rev.',
                                page='475', year=1993)]),
         )
         # fmt: on
@@ -569,37 +566,37 @@ class FindTest(TestCase):
         test_pairs = (
             # Test with atypical formatting for Tax Court Memos
             ('the 1 T.C. No. 233',
-             [case_citation(1, page='233', reporter='T.C. No.')]),
+             [case_citation(page='233', reporter='T.C. No.')]),
             ('word T.C. Memo. 2019-233',
-             [case_citation(1, 'T.C. Memo. 2019-233',
+             [case_citation('T.C. Memo. 2019-233',
                             page='233', reporter='T.C. Memo.',
                             volume='2019')]),
             ('something T.C. Summary Opinion 2019-233',
-             [case_citation(1, 'T.C. Summary Opinion 2019-233',
+             [case_citation('T.C. Summary Opinion 2019-233',
                             page='233', reporter='T.C. Summary Opinion',
                             volume='2019')]),
             ('T.C. Summary Opinion 2018-133',
-             [case_citation(0, 'T.C. Summary Opinion 2018-133',
+             [case_citation('T.C. Summary Opinion 2018-133',
                             page='133', reporter='T.C. Summary Opinion',
                             volume='2018')]),
             ('1     UNITED STATES TAX COURT REPORT   (2018)',
-             [case_citation(0, '1 UNITED STATES TAX COURT REPORT (2018)',
+             [case_citation('1 UNITED STATES TAX COURT REPORT (2018)',
                             volume='1', reporter='T.C.', page='2018',
                             reporter_found='UNITED STATES TAX COURT REPORT')],
              {'expect_fail': 'reporters.json needs UNITED STATES TAX COURT REPORT pattern with parens'}),
             ('U.S. of A. 1     UNITED STATES TAX COURT REPORT   (2018)',
-             [case_citation(3, '1 UNITED STATES TAX COURT REPORT (2018)',
+             [case_citation('1 UNITED STATES TAX COURT REPORT (2018)',
                             volume='1', reporter='T.C.', page='2018',
                             reporter_found='UNITED STATES TAX COURT REPORT')],
              {'expect_fail': 'reporters.json needs UNITED STATES TAX COURT REPORT pattern with parens'}),
             # Added this after failing in production
             ('     202                 140 UNITED STATES TAX COURT REPORTS                                   (200)',
-             [case_citation(1, '140 UNITED STATES TAX COURT REPORTS (200)',
+             [case_citation('140 UNITED STATES TAX COURT REPORTS (200)',
                             volume='140', reporter='T.C.', page='200',
                             reporter_found='UNITED STATES TAX COURT REPORTS')],
              {'expect_fail': 'reporters.json needs UNITED STATES TAX COURT REPORT pattern with parens'}),
             ('U.S. 1234 1 U.S. 1',
-             [case_citation(2, volume='1', reporter='U.S.', page='1')]),
+             [case_citation(volume='1', reporter='U.S.', page='1')]),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Tax court citation extraction")
@@ -630,44 +627,44 @@ class FindTest(TestCase):
         test_pairs = [
             # 1. P.R.R --> Correct abbreviation for a reporter.
             ('1 P.R.R. 1',
-             [case_citation(0, reporter='P.R.R.')]),
+             [case_citation(reporter='P.R.R.')]),
             # 2. U. S. --> A simple variant to resolve.
             ('1 U. S. 1',
-             [case_citation(0, reporter_found='U. S.')]),
+             [case_citation(reporter_found='U. S.')]),
             # 3. A.2d --> Not a variant, but needs to be looked up in the
             #    EDITIONS variable.
             ('1 A.2d 1',
-             [case_citation(0, reporter='A.2d')]),
+             [case_citation(reporter='A.2d')]),
             # 4. A. 2d --> An unambiguous variant of an edition
             ('1 A. 2d 1',
-             [case_citation(0, reporter='A.2d', reporter_found='A. 2d')]),
+             [case_citation(reporter='A.2d', reporter_found='A. 2d')]),
             # 5. P.R. --> A variant of 'Pen. & W.', 'P.R.R.', or 'P.' that's
             #    resolvable by year
             ('1 P.R. 1 (1831)',
              # Of the three, only Pen & W. was being published this year.
-             [case_citation(0, reporter='Pen. & W.',
+             [case_citation(reporter='Pen. & W.',
                             year=1831, reporter_found='P.R.')]),
             # 5.1: W.2d --> A variant of an edition that either resolves to
             #      'Wis. 2d' or 'Wash. 2d' and is resolvable by year.
             ('1 W.2d 1 (1854)',
              # Of the two, only Wis. 2d was being published this year.
-             [case_citation(0, reporter='Wis. 2d',
+             [case_citation(reporter='Wis. 2d',
                             year=1854, reporter_found='W.2d')]),
             # 5.2: Wash. --> A non-variant that has more than one reporter for
             #      the key, but is resolvable by year
             ('1 Wash. 1 (1890)',
-             [case_citation(0, reporter='Wash.', year=1890)]),
+             [case_citation(reporter='Wash.', year=1890)]),
             # 6. Cr. --> A variant of Cranch, which is ambiguous, except with
             #    paired with this variation.
             ('1 Cra. 1',
-             [case_citation(0, reporter='Cranch', reporter_found='Cra.',
+             [case_citation(reporter='Cranch', reporter_found='Cra.',
                             metadata={'court': 'scotus'})]),
             # 7. Cranch. --> Not a variant, but could refer to either Cranch's
             #    Supreme Court cases or his DC ones. In this case, we cannot
             #    disambiguate. Years are not known, and we have no further
             #    clues. We must simply drop Cranch from the results.
             ('1 Cranch 1 1 U.S. 23',
-             [case_citation(1, page='23')]),
+             [case_citation(page='23')]),
             # 8. Unsolved problem. In theory, we could use parallel citations
             #    to resolve this, because Rob is getting cited next to La., but
             #    we don't currently know the proximity of citations to each
@@ -681,7 +678,7 @@ class FindTest(TestCase):
             #  case_citation(volume='1', reporter='La.', page='1')]),
             # 9. Johnson #1 should pass and identify the citation
             ('1 Johnson 1 (1890)',
-             [case_citation(0, reporter='N.M. (J.)', reporter_found='Johnson',
+             [case_citation(reporter='N.M. (J.)', reporter_found='Johnson',
                             year=1890,
                             )]),
             # 10. Johnson #2 should fail to disambiguate with year alone
@@ -707,7 +704,7 @@ class FindTest(TestCase):
         # fmt: off
         test_pairs = [
             ('1 U,S, 1',
-             [case_citation(0, reporter_found='U,S,')]),
+             [case_citation(reporter_found='U,S,')]),
         ]
         # fmt: on
         self.run_test_pairs(

--- a/tests/test_ResolveTest.py
+++ b/tests/test_ResolveTest.py
@@ -13,47 +13,45 @@ from eyecite.test_factories import (
     supra_citation,
 )
 
-full1 = case_citation(1)
-full2 = case_citation(2)
+full1 = case_citation()
+full2 = case_citation()
 full3 = case_citation(
-    3, reporter="F.2d", metadata={"plaintiff": "Foo", "defendant": "Bar"}
+    reporter="F.2d", metadata={"plaintiff": "Foo", "defendant": "Bar"}
 )
-full4 = case_citation(4, metadata={"defendant": "Bar"})
-full5 = case_citation(5, metadata={"plaintiff": "Ipsum"})
-full6 = case_citation(6, reporter="F.2d", metadata={"plaintiff": "Ipsum"})
-full7 = case_citation(7, volume="1", reporter="U.S.")
+full4 = case_citation(metadata={"defendant": "Bar"})
+full5 = case_citation(metadata={"plaintiff": "Ipsum"})
+full6 = case_citation(reporter="F.2d", metadata={"plaintiff": "Ipsum"})
+full7 = case_citation(volume="1", reporter="U.S.")
 full8 = case_citation(
-    8, reporter="F.2d", volume="2", metadata={"defendant": "Ipsum"}
+    reporter="F.2d", volume="2", metadata={"defendant": "Ipsum"}
 )
 full9 = case_citation(
-    9, reporter="F.2d", page="99", metadata={"defendant": "Ipsum"}
+    reporter="F.2d", page="99", metadata={"defendant": "Ipsum"}
 )
-full10 = case_citation(10, reporter="F.2d", metadata={"plaintiff": "Foo"})
+full10 = case_citation(reporter="F.2d", metadata={"plaintiff": "Foo"})
 
-short1 = case_citation(1, volume="1", reporter="U.S.", short=True)
-short2 = case_citation(2, metadata={"antecedent_guess": "Bar"}, short=True)
+short1 = case_citation(volume="1", reporter="U.S.", short=True)
+short2 = case_citation(metadata={"antecedent_guess": "Bar"}, short=True)
 short3 = case_citation(
-    3, reporter="F.2d", metadata={"antecedent_guess": "Foo"}, short=True
+    reporter="F.2d", metadata={"antecedent_guess": "Foo"}, short=True
 )
 short4 = case_citation(
-    4, reporter="F.2d", metadata={"antecedent_guess": "wrong"}, short=True
+    reporter="F.2d", metadata={"antecedent_guess": "wrong"}, short=True
 )
 short5 = case_citation(
-    5, reporter="F.2d", metadata={"antecedent_guess": "Ipsum"}, short=True
+    reporter="F.2d", metadata={"antecedent_guess": "Ipsum"}, short=True
 )
 
-supra1 = supra_citation(1, metadata={"antecedent_guess": "Bar"})
-supra2 = supra_citation(2, metadata={"antecedent_guess": "Ipsum"})
+supra1 = supra_citation(metadata={"antecedent_guess": "Bar"})
+supra2 = supra_citation(metadata={"antecedent_guess": "Ipsum"})
 
-id1 = id_citation(1)
+id1 = id_citation()
 
-non1 = nonopinion_citation(1, source_text="§99")
+non1 = nonopinion_citation(source_text="§99")
 
-law1 = law_citation(
-    1, "Mass. Gen. Laws ch. 1, § 2", reporter="Mass. Gen. Laws"
-)
+law1 = law_citation("Mass. Gen. Laws ch. 1, § 2", reporter="Mass. Gen. Laws")
 
-journal1 = journal_citation(1)
+journal1 = journal_citation()
 
 # lookup table to help with printing more readable error messages:
 cite_to_name = {


### PR DESCRIPTION
Here's a couple of cleanup items following @ProbablyFaiz's discovery that I broke the test harness 😣:

* Update the short-citation test fixture to default court to `"scotus"` when reporter is `"U.S."`, the same way full citations already do. This removes a bunch of `'court': 'scotus'` from the individual tests.
* Go ahead and stop explicitly checking `cite.index` values -- checking those makes the test cases more annoying to write, and if `index` was wrong they would fail anyway because metadata extraction would fail. (The same is true for not checking `span()` -- if that was wrong the annotation test cases would fail.) Since we're not checking `index`, we can further streamline the test cases by defaulting `index` to `0` instead of explicitly setting it.