### PR TITLE
Extract parentheticals for supra and id cites

### DIFF
--- a/eyecite/find_citations.py
+++ b/eyecite/find_citations.py
@@ -215,6 +215,7 @@ def extract_supra_citation(
         metadata={
             "antecedent_guess": antecedent_guess,
             "pin_cite": pin_cite,
+            "parenthetical": parenthetical,
             "volume": volume,
         },
     )
@@ -235,5 +236,6 @@ def extract_id_citation(
         span_end=span_end,
         metadata={
             "pin_cite": pin_cite,
+            "parenthetical": parenthetical,
         },
     )

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -210,9 +210,13 @@ def extract_pin_cite(
         strings_only=True,
     )
     if m:
-        pin_cite = clean_pin_cite(m["pin_cite"]) or None
+        if m["pin_cite"]:
+            pin_cite = clean_pin_cite(m["pin_cite"])
+            extra_chars = len(m["pin_cite"].rstrip(", "))
+        else:
+            pin_cite = None
+            extra_chars = 0
         parenthetical = process_parenthetical(m["parenthetical"]) or None
-        extra_chars = m.span(1)[1]
         return (
             pin_cite,
             from_token.end + extra_chars - len(prefix),

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -94,7 +94,9 @@ class CitationBase:
 
     @dataclass(eq=True, unsafe_hash=True)
     class Metadata:
-        """Define fields on self.metadata. Base class doesn't have any."""
+        """Define fields on self.metadata."""
+
+        parenthetical: Optional[str] = None
 
     def corrected_citation(self):
         """Return citation with any variations normalized."""
@@ -155,10 +157,9 @@ class ResourceCitation(CitationBase):
         super().__post_init__()
 
     @dataclass(eq=True, unsafe_hash=True)
-    class Metadata:
+    class Metadata(CitationBase.Metadata):
         """Define fields on self.metadata."""
 
-        parenthetical: Optional[str] = None
         pin_cite: Optional[str] = None
         year: Optional[str] = None
 
@@ -382,7 +383,7 @@ class SupraCitation(CitationBase):
     """
 
     @dataclass(eq=True, unsafe_hash=True)
-    class Metadata:
+    class Metadata(CitationBase.Metadata):
         """Define fields on self.metadata."""
 
         antecedent_guess: Optional[str] = None
@@ -415,7 +416,7 @@ class IdCitation(CitationBase):
     """
 
     @dataclass(eq=True, unsafe_hash=True)
-    class Metadata:
+    class Metadata(CitationBase.Metadata):
         """Define fields on self.metadata."""
 
         pin_cite: Optional[str] = None

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -244,7 +244,7 @@ POST_FULL_CITATION_REGEX = rf"""
 #   parenthetical = overruling xyz
 POST_SHORT_CITATION_REGEX = rf"""
     # optional pin cite
-    {PIN_CITE_REGEX}
+    {PIN_CITE_REGEX}?
     \ ?
     # optional parenthetical comment:
     {PARENTHETICAL_REGEX}

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -338,6 +338,16 @@ class FindTest(TestCase):
             ('before asdf, supra end',
              [supra_citation("supra,",
                              metadata={'antecedent_guess': 'asdf'})]),
+            # Supra with parenthetical
+            ('Foo, supra (overruling ...)',
+             [supra_citation("supra",
+                             metadata={'antecedent_guess': 'Foo',
+                                       'parenthetical': 'overruling ...'})]),
+            ('Foo, supra, at 2 (overruling ...)',
+             [supra_citation("supra",
+                             metadata={'antecedent_guess': 'Foo',
+                                       'pin_cite': 'at 2',
+                                       'parenthetical': 'overruling ...'})]),
             # Test Ibid. citation
             ('foo v. bar 1 U.S. 12. asdf. Ibid. foo bar lorem ipsum.',
              [case_citation(page='12',
@@ -416,6 +426,13 @@ class FindTest(TestCase):
                                       'defendant': 'bar',
                                       'pin_cite': '347-348'}),
               id_citation('Id.')]),
+            # Id. with parenthetical
+            ('Id. (overruling ...)',
+             [id_citation("Id.", metadata={'parenthetical': 'overruling ...'})]),
+            ('Id. at 2 (overruling ...)',
+             [id_citation("Id.",
+                          metadata={'pin_cite': 'at 2',
+                                    'parenthetical': 'overruling ...'})]),
             # Test non-opinion citation
             ('lorem ipsum see §99 of the U.S. code.',
              [nonopinion_citation('§99')]),


### PR DESCRIPTION
Following up on #62:

> One upshot of the way I implemented this functionality in extract_pin_citation is that parentheticals attached to Id and Supra citations are now also captured. They are not used, however, because the Id and Supra citation classes don't currently have a parenthetical field in their metadata. I'm a little wary of tampering with a class model I don't fully understand at the moment, so I'll leave that to you guys.

This sets `cite.metadata.parenthetical` for id. and supra cites.