### PR TITLE
Call process_parenthetical for laws and journals

### DIFF
--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -89,9 +89,7 @@ def add_post_citation(citation: CaseCitation, words: Tokens) -> None:
 
     citation.metadata.pin_cite = clean_pin_cite(m["pin_cite"]) or None
     citation.metadata.extra = (m["extra"] or "").strip() or None
-    citation.metadata.parenthetical = (
-        process_parenthetical(m["parenthetical"]) or None
-    )
+    citation.metadata.parenthetical = process_parenthetical(m["parenthetical"])
     citation.metadata.year = m["year"]
     if m["year"]:
         citation.year = get_year(m["year"])
@@ -139,7 +137,7 @@ def add_law_metadata(citation: FullLawCitation, words: Tokens) -> None:
     citation.metadata.publisher = m["publisher"]
     citation.metadata.day = m["day"]
     citation.metadata.month = m["month"]
-    citation.metadata.parenthetical = m["parenthetical"]
+    citation.metadata.parenthetical = process_parenthetical(m["parenthetical"])
     citation.metadata.year = m["year"]
     if m["year"]:
         citation.year = get_year(m["year"])
@@ -157,7 +155,7 @@ def add_journal_metadata(citation: FullJournalCitation, words: Tokens) -> None:
         return
 
     citation.metadata.pin_cite = clean_pin_cite(m["pin_cite"]) or None
-    citation.metadata.parenthetical = m["parenthetical"]
+    citation.metadata.parenthetical = process_parenthetical(m["parenthetical"])
     citation.metadata.year = m["year"]
     if m["year"]:
         citation.year = get_year(m["year"])
@@ -188,10 +186,10 @@ def process_parenthetical(
         elif char == ")":
             paren_balance -= 1
         if paren_balance < 0:  # End parenthetical reached
-            return matched_parenthetical[:i]
+            return matched_parenthetical[:i] or None
     if re.match(YEAR_REGEX, matched_parenthetical, flags=re.X):
         return None
-    return matched_parenthetical
+    return matched_parenthetical or None
 
 
 def extract_pin_cite(
@@ -216,7 +214,7 @@ def extract_pin_cite(
         else:
             pin_cite = None
             extra_chars = 0
-        parenthetical = process_parenthetical(m["parenthetical"]) or None
+        parenthetical = process_parenthetical(m["parenthetical"])
         return (
             pin_cite,
             from_token.end + extra_chars - len(prefix),

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -339,7 +339,7 @@ class FindTest(TestCase):
              [supra_citation("supra,",
                              metadata={'antecedent_guess': 'asdf'})]),
             # Supra with parenthetical
-            ('Foo, supra (overruling ...)',
+            ('Foo, supra (overruling ...) (ignore this)',
              [supra_citation("supra",
                              metadata={'antecedent_guess': 'Foo',
                                        'parenthetical': 'overruling ...'})]),
@@ -427,7 +427,7 @@ class FindTest(TestCase):
                                       'pin_cite': '347-348'}),
               id_citation('Id.')]),
             # Id. with parenthetical
-            ('Id. (overruling ...)',
+            ('Id. (overruling ...) (ignore this)',
              [id_citation("Id.", metadata={'parenthetical': 'overruling ...'})]),
             ('Id. at 2 (overruling ...)',
              [id_citation("Id.",
@@ -514,7 +514,7 @@ class FindTest(TestCase):
                            reporter='Mass. Gen. Laws',
                            groups={'chapter': '1', 'section': '2-3'})]),
             # parenthetical
-            ('Kan. Stat. Ann. § 21-3516(a)(2) (repealed)',
+            ('Kan. Stat. Ann. § 21-3516(a)(2) (repealed) (ignore this)',
              [law_citation('Kan. Stat. Ann. § 21-3516(a)(2) (repealed)',
                            reporter='Kan. Stat. Ann.',
                            metadata={'pin_cite': '(a)(2)', 'parenthetical': 'repealed'},
@@ -566,7 +566,7 @@ class FindTest(TestCase):
             ('1 Minn. L. Rev. 1, 2-3 (2007)',
              [journal_citation(metadata={'pin_cite': '2-3'}, year=2007)]),
             # Pin cite and year and parenthetical
-            ('1 Minn. L. Rev. 1, 2-3 (2007) (discussing ...)',
+            ('1 Minn. L. Rev. 1, 2-3 (2007) (discussing ...) (ignore this)',
              [journal_citation(year=2007,
                                metadata={'pin_cite': '2-3', 'parenthetical': 'discussing ...'})]),
             # Year range


### PR DESCRIPTION
`process_parenthetical` was missing from `add_law_metadata` and `add_journal_metadata`, so `LawCitation` and `JournalCitation` were capturing text beyond the end of their actual parentheticals.

Also in this PR:
* `process_parenthetical` returns `None` for empty parentheticals to make the calling sites less verbose. 
* Update tests to ensure that law/journal/supra/id cites don't capture more of the parenthetical than they should.