### PR TITLE
Fix Bankr. L. Rep. test for new reporters-db

### DIFF
--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -60,8 +60,7 @@ def case_citation(
         source_text = f"{volume} {reporter} {page}"
     if short:
         metadata.setdefault("pin_cite", page)
-    if volume:
-        groups.setdefault("volume", volume)
+    groups.setdefault("volume", volume)
     groups.setdefault("page", page)
     cls = ShortCaseCitation if short else FullCaseCitation
     return resource_citation(cls, source_text, reporter, short, **kwargs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,7 +283,7 @@ python-versions = "*"
 
 [[package]]
 name = "reporters-db"
-version = "3.1.1"
+version = "3.2.0"
 description = "Database of Court Reporters"
 category = "main"
 optional = false
@@ -355,7 +355,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "cb27e4696c03d591f1722a5adb87cd61c19d73a891a0414d93edcc21f65863b8"
+content-hash = "b756437f6d6cead09a6332af625bf24f07c3510670177b9c8bd239db3d810bd8"
 
 [metadata.files]
 appdirs = [
@@ -603,8 +603,8 @@ regex = [
     {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
 ]
 reporters-db = [
-    {file = "reporters-db-3.1.1.tar.gz", hash = "sha256:d3da82e7a1520746d110afee994e1c470534d9d54536ea1fca2ea5a457b5c056"},
-    {file = "reporters_db-3.1.1-py2.py3-none-any.whl", hash = "sha256:4b2d49c9d0b48cdc875c6b998ffce69f0cff1058dd89c28041578776329a1c08"},
+    {file = "reporters-db-3.2.0.tar.gz", hash = "sha256:0ebd9c0233154b511e57723a992243ea0f430d36c89fa53fa5c03905e7a3a999"},
+    {file = "reporters_db-3.2.0-py2.py3-none-any.whl", hash = "sha256:b79b50a3e9f4a3ac82b86053cbf02de38002cb3330e2e35964638035ef10008e"},
 ]
 roman = [
     {file = "roman-3.3-py2.py3-none-any.whl", hash = "sha256:c2a1f14ab47373aecc141edbcdd66595949c9d0ed932fe76bd547df1b55f7278"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = ["eyecite/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-reporters-db = "^3.1.1"
+reporters-db = "^3.2"
 courts-db = "^0.9.7"
 lxml = "^4.6.3"
 pyahocorasick = ">= 1.2"

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -440,7 +440,7 @@ class FindTest(TestCase):
              [case_citation()]),
             # Test reporter with custom regex
             ('blah blah Bankr. L. Rep. (CCH) P12,345. blah blah',
-             [case_citation(volume='', reporter='Bankr. L. Rep.',
+             [case_citation(volume=None, reporter='Bankr. L. Rep.',
                             reporter_found='Bankr. L. Rep. (CCH)', page='12,345')]),
             ('blah blah, 2009 12345 (La.App. 1 Cir. 05/10/10). blah blah',
              [case_citation(volume='2009', reporter='La.App. 1 Cir.',


### PR DESCRIPTION
The latest reporters-db code ([PR](https://github.com/freelawproject/reporters-db/pull/59)) changed the match groups for `Bankr. L. Rep. (CCH) P12,345` so they come in as `groups={"volume": None ...}` instead of not having a volume key. This is because CCH cites sometimes have a volume and sometimes don't, so there's now an optional match group to check for it.

So, this PR just updates the eyecite tests to expect that `"volume": None` value. It will pass against the latest reporters-db but not against the one on PyPI, so I'm not sure how you want to sequence things.