### PR TITLE
Avoid backtracking in pin cite regex

### DIFF
--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -127,12 +127,14 @@ MONTH_REGEX = r"""
 """
 
 YEAR_REGEX = r"""
-    (?P<year>
-        \d{4}
+    (?:
+        (?P<year>
+            \d{4}
+        )
+        # Year is occasionally a range, like "1993-94" or "2005-06".
+        # For now we ignore the end of the range:
+        (?:-\d{2})?
     )
-    # Year is occasionally a range, like "1993-94" or "2005-06".
-    # For now we ignore the end of the range:
-    (?:-\d{2})?
 """
 
 # Pin cite regex:
@@ -164,14 +166,18 @@ PIN_CITE_TOKEN_REGEX = r"""
 """
 PIN_CITE_REGEX = rf"""
     (?P<pin_cite>
-        (?:,?\ ?at)?
-        (?:,?\ ?{PIN_CITE_TOKEN_REGEX})+
+        # optional comma, space, "at" before pin cite
+        ,?\ ?(?:at\ )?
+        # first mandatory page number
+        {PIN_CITE_TOKEN_REGEX}
+        # optional additional page numbers
+        (?:,\ ?{PIN_CITE_TOKEN_REGEX})*
         # pin cite must be followed by one of these so it doesn't capture
         # start of next citation
         (?=
             [,.;)\]\\]|  # ending punctuation
-            \ ?[(\[]|   # space and start of parens
-            $          # end of text
+            \ ?[(\[]|    # space and start of parens
+            $            # end of text
         )
     )
 """

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -465,6 +465,9 @@ class FindTest(TestCase):
             ('Id. foo', [id_citation('Id.,')]),
             # Reject citations that are part of larger words
             ('foo1 U.S. 1, 1. U.S. 1foo', [],),
+            # Long pin cite -- make sure no catastrophic backtracking in regex
+            ('1 U.S. 1, 2277, 2278, 2279, 2280, 2281, 2282, 2283, 2284, 2286, 2287, 2288, 2289, 2290, 2291',
+             [case_citation(metadata={'pin_cite': '2277, 2278, 2279, 2280, 2281, 2282, 2283, 2284, 2286, 2287, 2288, 2289, 2290, 2291'})]),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Citation extraction")


### PR DESCRIPTION
When reindexing CAP we ran into [catastrophic backtracking](https://www.regular-expressions.info/catastrophic.html) in the pin cite regex -- metadata extraction would take forever on long pin cites like `'2277, 2278, 2279, 2280, 2281, 2282, 2283, 2284, 2286, 2287, 2288, 2289, 2290, 2291'`. Turns out the core problem is the regex is looking for an optional `, ` between every page number, which gave it a huge number of options to check in that example, when it needs to look for optional `, ` only before the first page number, and mandatory `, ` for subsequent page numbers.

Also in this PR, a tweak to `YEAR_REGEX` so `{YEAR_REGEX}?` will work as expected.