### PR TITLE
More flexible short cite generation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
  - None yet
 
 Fixes:
- - None yet
+ - Initial support for finding short cites with non-standard regexes, including fixing short cite extraction for `Mich.`, `N.Y.2d` and `Pa.`. 
 
 ## Current
 

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -1,4 +1,5 @@
 # *** Helpers for building regexes: ***
+import regex as re
 
 
 def space_boundaries_re(regex):
@@ -14,6 +15,28 @@ def strip_punctuation_re(regex):
 def nonalphanum_boundaries_re(regex):
     """Wrap regex to require non-alphanumeric characters on left and right."""
     return rf"(?:^|[^a-zA-Z0-9])({regex})(?:[^a-zA-Z0-9]|$)"
+
+
+def short_cite_re(regex):
+    """Convert a full citation regex into a short citation regex.
+    Currently this just means we turn '(?P<reporter>...),? (?P<page>...'
+    to '(?P<reporter>...),? at (?P<page>...'"""
+    return re.sub(
+        r"""
+            # reporter group:
+            (
+                \(\?P<reporter>[^)]+\)
+            )
+            (?:,\?)?\  # comma and space
+            # page group:
+            (
+                \(\?P<page>
+            )
+        """,
+        r"\1,? at \2",
+        regex,
+        flags=re.VERBOSE,
+    )
 
 
 # *** Tokenizer regexes: ***

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -296,8 +296,16 @@ class Tokenizer:
         tokens = sorted(
             self.extract_tokens(text), key=lambda m: (m.start, -m.end)
         )
+        last_token = None
         offset = 0
         for token in tokens:
+            if last_token:
+                # Sometimes the exact same cite is matched by two different
+                # regexes. Attempt to merge rather than discarding one or the
+                # other:
+                merged = last_token.merge(token)
+                if merged:
+                    continue
             if offset > token.start:
                 # skip overlaps
                 continue
@@ -308,6 +316,7 @@ class Tokenizer:
             citation_tokens.append((len(all_tokens), token))
             all_tokens.append(token)
             offset = token.end
+            last_token = token
         # capture plain text after final match
         if offset < len(text):
             self.append_text(all_tokens, text[offset:])

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -42,6 +42,7 @@ from eyecite.regexes import (
     STOP_WORDS,
     SUPRA_REGEX,
     nonalphanum_boundaries_re,
+    short_cite_re,
 )
 
 # Prepare extractors
@@ -63,15 +64,11 @@ def _populate_reporter_extractors():
     raw_regex_variables["full_cite"][""] = "$volume $reporter,? $page"
     raw_regex_variables["page"][""] = rf"(?P<page>{PAGE_NUMBER_REGEX})"
     regex_variables = process_variables(raw_regex_variables)
-    short_cite_template = recursive_substitute(
-        "$volume $reporter,? at $page", regex_variables
-    )
 
-    def _substitute_edition(template, edition_name):
-        """Helper to replace $edition in template with edition_name."""
-        return Template(template).safe_substitute(
-            edition=re.escape(edition_name)
-        )
+    def _substitute_edition(template, *edition_names):
+        """Helper to replace $edition in template with edition_names."""
+        edition = "|".join(re.escape(e) for e in edition_names)
+        return Template(template).safe_substitute(edition=edition)
 
     # Extractors step one: add an extractor for each reporter string
 
@@ -99,42 +96,51 @@ def _populate_reporter_extractors():
 
     def _add_regex(
         kind: str,
-        reporter: str,
+        reporters: List[str],
         edition: Edition,
         regex: str,
-        standard_cite: bool,
     ):
         """Helper to generate citations for a reporter
         and insert into editions_by_regex."""
-        EDITIONS_LOOKUP[reporter].append(edition)
+        for reporter in reporters:
+            EDITIONS_LOOKUP[reporter].append(edition)
         editions_by_regex[regex][kind].append(edition)
 
-        if standard_cite:
-            editions_by_regex[regex]["strings"].add(reporter)
+        # add strings
+        have_strings = re.escape(reporters[0]) in regex
+        if have_strings:
+            editions_by_regex[regex]["strings"].update(reporters)
 
-            # add short cite
-            regex = _substitute_edition(short_cite_template, reporter)
-            editions_by_regex[regex][kind].append(edition)
-            editions_by_regex[regex]["strings"].add(reporter)
-            editions_by_regex[regex]["short"] = True
+        # add short cite
+        short_cite_regex = short_cite_re(regex)
+        if short_cite_regex != regex:
+            editions_by_regex[short_cite_regex][kind].append(edition)
+            editions_by_regex[short_cite_regex]["short"] = True
+            if have_strings:
+                editions_by_regex[short_cite_regex]["strings"].update(
+                    reporters
+                )
 
-    def _add_regexes(regex_templates, edition_name, edition, variations):
+    def _add_regexes(
+        regex_templates: List[str],
+        edition_name: str,
+        edition: Edition,
+        variations: List[str],
+    ):
         """Expand regex_templates and add to editions_by_regex."""
         for regex_template in regex_templates:
-            standard_cite = regex_template == "$full_cite"
             regex_template = recursive_substitute(
                 regex_template, regex_variables
             )
             regex = _substitute_edition(regex_template, edition_name)
-            _add_regex("editions", edition_name, edition, regex, standard_cite)
-            for variation in variations:
-                regex = _substitute_edition(regex_template, variation)
+            _add_regex("editions", [edition_name], edition, regex)
+            if variations:
+                regex = _substitute_edition(regex_template, *variations)
                 _add_regex(
                     "variations",
-                    variation,
+                    variations,
                     edition,
                     regex,
-                    standard_cite,
                 )
 
     # add reporters.json:

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,7 +283,7 @@ python-versions = "*"
 
 [[package]]
 name = "reporters-db"
-version = "3.2.0"
+version = "3.2.1"
 description = "Database of Court Reporters"
 category = "main"
 optional = false
@@ -634,8 +634,8 @@ regex = [
     {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
 ]
 reporters-db = [
-    {file = "reporters-db-3.2.0.tar.gz", hash = "sha256:0ebd9c0233154b511e57723a992243ea0f430d36c89fa53fa5c03905e7a3a999"},
-    {file = "reporters_db-3.2.0-py2.py3-none-any.whl", hash = "sha256:b79b50a3e9f4a3ac82b86053cbf02de38002cb3330e2e35964638035ef10008e"},
+    {file = "reporters-db-3.2.1.tar.gz", hash = "sha256:cc8f0d0a6333190ff7f93d2d3a0c7cd47349eca842aed693a79c7562645b312f"},
+    {file = "reporters_db-3.2.1-py2.py3-none-any.whl", hash = "sha256:5b095da3489a17d71a7328d22df3b1f0b8f176a2bc7b20b7a5254a7a809f10a7"},
 ]
 roman = [
     {file = "roman-3.3-py2.py3-none-any.whl", hash = "sha256:c2a1f14ab47373aecc141edbcdd66595949c9d0ed932fe76bd547df1b55f7278"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = ["eyecite/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-reporters-db = "^3.2"
+reporters-db = "^3.2.1"
 lxml = "^4.6.3"
 pyahocorasick = ">= 1.2"
 diff_match_patch_python = "^1.0.2"

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -279,6 +279,9 @@ class FindTest(TestCase):
                                       'parenthetical': 'discussing abc'}
                             )]
              ),
+            # Test short form citation generated from non-standard regex for full cite
+            ('1 Mich. at 1',
+             [case_citation(reporter='Mich.', short=True)]),
             # Test parenthetical matching with multiple citations
             ('1 U. S., at 2. foo v. bar 3 U. S. 4 (2010) (overruling xyz).',
              [case_citation(page='2', reporter='U.S.',


### PR DESCRIPTION
I noticed that we weren't getting short cites for the `Mich.` reporter, which turns out to be because that reporter has a non-standard volume number in its regex, and we currently only look for short cites for the standard regex.

So this PR does three related things:

* Add a `short_cite_re` function to more flexibly generate short-cite regexes from full cite regexes. Currently this is only slightly more flexible than before, but does successfully work for `Mich.`: it tries to insert an " at " between the `(?P<reporter>...)` and `(?P<page>...)` groups. This could get smarter if we figure out rules for other cite formats.
* When generating regexes for variant editions, put them in a single regex like `(?P<reporter>Mich|Mich Foo|etc.)` instead of making a separate regex for each of them. This is a little more efficient, particularly if you aren't using hyperscan, and was convenient to do while fixing up short cites.
* If two regexes have the exact same results, combine them into one, using the new `Token.merge` function. This avoids a situation where we fail to disambiguate properly because two reporters are looking for the same pattern with slightly different regexes.