### PR TITLE
Improve tutorial and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 eyecite
 ==========
 
-eyecite is an open source tool for extracting legal citations from text. It is used, among other things, to process millions of legal documents in the collections of `CourtListener <https://www.courtlistener.com/>`_ and the `Caselaw Access Project <https://case.law/>`_.
+eyecite is an open source tool for extracting legal citations from text. It is used, among other things, to process millions of legal documents in the collections of `CourtListener <https://www.courtlistener.com/>`_ and Harvard's `Caselaw Access Project <https://case.law/>`_, and has been developed in collaboration with both projects.
 
 eyecite recognizes a wide variety of citations commonly appearing in American legal decisions, including:
 
@@ -236,7 +236,7 @@ intelligently adjust the annotation positions using the diff-match-patch library
 Ta da!
 
 Documentation
-=================
+=============
 
 eyecite's full API is documented `here <https://freelawproject.github.io/eyecite/>`_, but here are details regarding its four core functions, its tokenization logic, and its debugging tools.
 


### PR DESCRIPTION
This PR makes several improvements to our README.

First, re #94, it adds to the top a clear list of the four core functions of eyecite: extraction, aggregation (resolution), annotation, and cleaning.

Second, re #95, it clarifies the tutorial regarding the hypothetical "database" and other confusing items. All the code in the tutorial is now definitely run-able by the reader, except for two sections that offer psuedo-code for expanded functionality (the `resolutions2` and `annotations2` sections). I also attempted to clarify those sections themselves by providing more details about how one might integrate with an external database or API. It should hopefully be clear that eyecite works fine without doing that, but the pseudo-code should still be helpful for users trying to exploit that functionality.

This PR shouldn't be merged before #96 since I added some links (that don't work) to the new API documentation. This also doesn't address all the open issues re the README; some things (re tests and bigger examples) may still need to be added.