### PR TITLE
Issue 30 find partial page citations

### DIFF
--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -63,7 +63,8 @@ ROMAN_NUMERAL_REGEX = "|".join(
 # (ordered in descending order of likelihood)
 # 1) A plain digit. E.g. "123"
 # 2) A roman numeral.
-PAGE_NUMBER_REGEX = rf"(?:\d+|{ROMAN_NUMERAL_REGEX})"
+# 3) A page placeholder. E.g. "Carpenter v. United States, 585 U.S. ___ (2018)"
+PAGE_NUMBER_REGEX = rf"(?:\d+|{ROMAN_NUMERAL_REGEX}|_+)"
 
 # Regex to match punctuation around volume numbers and stopwords.
 # This could potentially be more precise.

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -181,8 +181,11 @@ class FindTest(TestCase):
             # Test with page range with a weird suffix
             ('559 N.W.2d 826|N.D.',
              [case_citation(page='826', reporter='N.W.2d', volume='559')]),
-            # Test with malformed/missing page number
+            # Test with malformed page number
             ('1 U.S. f24601', []),
+            # Test with page number that is indicated as missing
+            ('1 U.S. ___',
+             [case_citation(volume='1', reporter='U.S.', page='___')]),
             # Test with the 'digit-REPORTER-digit' corner-case formatting
             ('2007-NMCERT-008',
              [case_citation(source_text='2007-NMCERT-008', page='008',

--- a/tests/test_ResolveTest.py
+++ b/tests/test_ResolveTest.py
@@ -241,6 +241,14 @@ class ResolveTest(TestCase):
             (1, "Ala. Code § 92"),
             (1, "Id. at 2000"),
         )
+        # Test resolving an Id. citation with a pin cite when the previous
+        # citation only has a placeholder page. We expect this to still resolve
+        # because it's possible to pin cite to an opinion with pending final
+        # page numbers.
+        self.checkResolution(
+            (0, "Foo v. Bar, 1 U.S. ___"),
+            (0, "Id. at 100."),
+        )
 
     def test_non_case_resolution(self):
         """Test law and journal resolution."""


### PR DESCRIPTION
This enables `eyecite` to find citations that don't yet have a final page number, but just have a placeholder `___` space instead. This is common with the `U.S.` reporter. This simple parsing change is the first half of addressing #30; figuring out how to match these partial citations will have to be done in CL.

Two things I thought of but didn't include:
1) Should we add a metadata flag to the citation objects like `has_proper_page_number` or something? This would be `False` if the page number is all underscores, `True` otherwise. I wasn't sure if this would actually be helpful or not.
2) Are there other characters besides underscores that courts use to indicate a placeholder for an eventual page number?