### PR TITLE
Fixed parenthesis, added full_span function and test

### DIFF
--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -105,7 +105,7 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
     future, this could be improved.
     """
     # To turn word indexing into char indexing, useful for span, account for shift
-    offset = 1
+    offset = 0
     start_index = None
     back_seek = citation.index - BACKWARD_SEEK
     for index in range(citation.index - 1, max(back_seek, -1), -1):
@@ -119,7 +119,11 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
                 citation.metadata.plaintiff = "".join(
                     str(w) for w in words[max(index - 2, 0): index]
                 ).strip()
-                offset += len(citation.metadata.plaintiff)
+                offset += len(citation.metadata.plaintiff) + 1
+            else:
+                # We don't want to include stop words such as 'citing' in the span
+                offset -= len(word)
+
             start_index = index + 1
             break
         if word.endswith(";"):

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -104,7 +104,8 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
     etc. If no known stop-token is found, no defendant name is stored.  In the
     future, this could be improved.
     """
-    # To turn word indexing into char indexing, useful for span, account for shift
+    # To turn word indexing into char indexing,
+    # useful for span, account for shift
     offset = 0
     start_index = None
     back_seek = citation.index - BACKWARD_SEEK
@@ -117,11 +118,12 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
         if isinstance(word, StopWordToken):
             if word.groups["stop_word"] == "v" and index > 0:
                 citation.metadata.plaintiff = "".join(
-                    str(w) for w in words[max(index - 2, 0): index]
+                    str(w) for w in words[max(index - 2, 0) : index]
                 ).strip()
                 offset += len(citation.metadata.plaintiff) + 1
             else:
-                # We don't want to include stop words such as 'citing' in the span
+                # We don't want to include stop words such as
+                # 'citing' in the span
                 offset -= len(word)
 
             start_index = index + 1
@@ -132,7 +134,7 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
     if start_index:
         citation.full_span_start = citation.span()[0] - offset
         citation.metadata.defendant = "".join(
-            str(w) for w in words[start_index: citation.index]
+            str(w) for w in words[start_index : citation.index]
         ).strip(", ")
 
 

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -88,6 +88,7 @@ def add_post_citation(citation: CaseCitation, words: Tokens) -> None:
     if not m:
         return
 
+    citation.full_span_end = citation.span()[1] + m.end()
     citation.metadata.pin_cite = clean_pin_cite(m["pin_cite"]) or None
     citation.metadata.extra = (m["extra"] or "").strip() or None
     citation.metadata.parenthetical = process_parenthetical(m["parenthetical"])
@@ -103,26 +104,31 @@ def add_defendant(citation: CaseCitation, words: Tokens) -> None:
     etc. If no known stop-token is found, no defendant name is stored.  In the
     future, this could be improved.
     """
+    # To turn word indexing into char indexing, useful for span, account for shift
+    offset = 1
     start_index = None
     back_seek = citation.index - BACKWARD_SEEK
     for index in range(citation.index - 1, max(back_seek, -1), -1):
         word = words[index]
+        offset += len(word)
         if word == ",":
             # Skip it
             continue
         if isinstance(word, StopWordToken):
             if word.groups["stop_word"] == "v" and index > 0:
                 citation.metadata.plaintiff = "".join(
-                    str(w) for w in words[max(index - 2, 0) : index]
+                    str(w) for w in words[max(index - 2, 0): index]
                 ).strip()
+                offset += len(citation.metadata.plaintiff)
             start_index = index + 1
             break
         if word.endswith(";"):
             # String citation
             break
     if start_index:
+        citation.full_span_start = citation.span()[0] - offset
         citation.metadata.defendant = "".join(
-            str(w) for w in words[start_index : citation.index]
+            str(w) for w in words[start_index: citation.index]
         ).strip(", ")
 
 
@@ -134,6 +140,7 @@ def add_law_metadata(citation: FullLawCitation, words: Tokens) -> None:
     if not m:
         return
 
+    citation.full_span_end = citation.span()[1] + m.end()
     citation.metadata.pin_cite = clean_pin_cite(m["pin_cite"]) or None
     citation.metadata.publisher = m["publisher"]
     citation.metadata.day = m["day"]
@@ -155,6 +162,7 @@ def add_journal_metadata(citation: FullJournalCitation, words: Tokens) -> None:
     if not m:
         return
 
+    citation.full_span_end = citation.span()[1] + m.end()
     citation.metadata.pin_cite = clean_pin_cite(m["pin_cite"]) or None
     citation.metadata.parenthetical = process_parenthetical(m["parenthetical"])
     citation.metadata.year = m["year"]

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -69,7 +69,9 @@ class CitationBase:
     index: int  # index of _token in the token list
     # span() overrides
     span_start: Optional[int] = None
+    full_span_start: Optional[int] = None
     span_end: Optional[int] = None
+    full_span_end: Optional[int] = None
     groups: dict = field(default_factory=dict)
     metadata: Any = None
 
@@ -144,6 +146,13 @@ class CitationBase:
             if self.span_start is not None
             else self.token.start,
             self.span_end if self.span_end is not None else self.token.end,
+        )
+
+    def full_span(self):
+        """Start and Stop offsets in source text for full citation text (including plaintiff, defendant, post citation, ...)"""
+        return (
+            self.full_span_start if self.full_span_start else self.span()[0],
+            self.full_span_end if self.full_span_end else self.span()[1]
         )
 
 
@@ -262,7 +271,7 @@ class FullLawCitation(FullCitation):
             i for i in (m.publisher, m.month, m.day, m.year) if i
         )
         if publisher_date:
-            parts.append(f" ({publisher_date}")
+            parts.append(f" ({publisher_date})")
         if m.parenthetical:
             parts.append(f" ({m.parenthetical})")
         return "".join(parts)
@@ -358,7 +367,7 @@ class FullCaseCitation(CaseCitation, FullCitation):
             parts.append(f", {m.pin_cite}")
         if m.extra:
             parts.append(m.extra)
-        publisher_date = " ".join(m[i] for i in (m.court, m.year) if i)
+        publisher_date = " ".join(i for i in (m.court, m.year) if i)
         if publisher_date:
             parts.append(f" ({publisher_date}")
         if m.parenthetical:

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -69,8 +69,8 @@ class CitationBase:
     index: int  # index of _token in the token list
     # span() overrides
     span_start: Optional[int] = None
-    full_span_start: Optional[int] = None
     span_end: Optional[int] = None
+    full_span_start: Optional[int] = None
     full_span_end: Optional[int] = None
     groups: dict = field(default_factory=dict)
     metadata: Any = None
@@ -149,11 +149,20 @@ class CitationBase:
         )
 
     def full_span(self):
-        """Start and Stop offsets in source text for full citation text (including plaintiff, defendant, post citation, ...)"""
-        return (
-            self.full_span_start if self.full_span_start else self.span()[0],
-            self.full_span_end if self.full_span_end else self.span()[1]
-        )
+        """Span indices that fully cover the citation
+
+        Start and stop offsets in source text for full citation text (including plaintiff, defendant, post citation, ...)
+        Relevant for FullCaseCitation, FullJournalCitation and FullLawCitation.
+        """
+        start = self.full_span_start
+        if start is None:
+            start = self.span()[0]
+
+        end = self.full_span_end
+        if end is None:
+            end = self.span()[1]
+
+        return (start, end)
 
 
 @dataclass(eq=True, unsafe_hash=True, repr=False)

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
     Union,
     cast,
 )
@@ -148,11 +149,15 @@ class CitationBase:
             self.span_end if self.span_end is not None else self.token.end,
         )
 
-    def full_span(self):
+    def full_span(self) -> Tuple[int, int]:
         """Span indices that fully cover the citation
 
-        Start and stop offsets in source text for full citation text (including plaintiff, defendant, post citation, ...)
+        Start and stop offsets in source text for full citation text (including
+        plaintiff, defendant, post citation, ...)
+
         Relevant for FullCaseCitation, FullJournalCitation and FullLawCitation.
+
+        :returns: Tuple of start and end indicies
         """
         start = self.full_span_start
         if start is None:
@@ -162,7 +167,7 @@ class CitationBase:
         if end is None:
             end = self.span()[1]
 
-        return (start, end)
+        return start, end
 
 
 @dataclass(eq=True, unsafe_hash=True, repr=False)

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -739,13 +739,24 @@ class FindTest(TestCase):
             '37 A.L.R.4th 972, 974 (1985)',
             '497 Fed. Appx. 274 (4th Cir. 2012)',
             "Corp. v. Nature's Farm Prods., No. 99 Civ. 9404 (SHS), 2000 U.S. Dist. LEXIS 12335 (S.D.N.Y. Aug. 25, 2000)",
-            "Alderson v. Concordia Par. Corr. Facility, 848 F.3d 415 (5th Cir. 2017)"
+            "Alderson v. Concordia Par. Corr. Facility, 848 F.3d 415 (5th Cir. 2017)",
         ]
         for example in simple_examples:
             extracted = get_citations(example)[0]
-            print(extracted, extracted.full_span(), len(example))
             error_msg = "Full span indices for a simple example should be (0, len(example)) "
             self.assertEqual(extracted.full_span(),
                              (0, len(example)),
+                             error_msg
+                             )
+        # Sentence and correct start_index
+        stopword_examples = [
+            ("See 66 B.U. L. Rev. 71 (1986)", 4),
+            ("Citing 66 B.U. L. Rev. 71 (1986)", 7)
+        ]
+        for sentence, start_idx in stopword_examples:
+            extracted = get_citations(sentence)[0]
+            error_msg = "Wrong span for stopword example"
+            self.assertEqual(extracted.full_span(),
+                             (start_idx, len(sentence)),
                              error_msg
                              )

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -714,7 +714,7 @@ class FindTest(TestCase):
         """Check that the full_span function returns the correct indices."""
 
         # Make sure it works with several citations in one string
-        combined_example = 'citation number one is Wilson v. Mar. Overseas Corp., 150 F.3d 1, 6-7 ( 1st Cir. 1998); This is different from Commonwealth v. Bauer, 604 A.2d 1098 (Pa.Super. 1992), my second example'
+        combined_example = "citation number one is Wilson v. Mar. Overseas Corp., 150 F.3d 1, 6-7 ( 1st Cir. 1998); This is different from Commonwealth v. Bauer, 604 A.2d 1098 (Pa.Super. 1992), my second example"
         extracted = get_citations(combined_example)
         # answers format is (citation_index, (full_span_start, full_span_end))
         answers = [(0, (23, 86)), (1, (111, 164))]
@@ -733,30 +733,28 @@ class FindTest(TestCase):
 
         # full_span should cover the whole string
         simple_examples = [
-            '66 B.U. L. Rev. 71 (1986)',
-            '5 Minn. L. Rev. 1339, 1341 (1991)',
-            '42 U.S.C. § 405(r)(2) (2019)',
-            '37 A.L.R.4th 972, 974 (1985)',
-            '497 Fed. Appx. 274 (4th Cir. 2012)',
+            "66 B.U. L. Rev. 71 (1986)",
+            "5 Minn. L. Rev. 1339, 1341 (1991)",
+            "42 U.S.C. § 405(r)(2) (2019)",
+            "37 A.L.R.4th 972, 974 (1985)",
+            "497 Fed. Appx. 274 (4th Cir. 2012)",
             "Corp. v. Nature's Farm Prods., No. 99 Civ. 9404 (SHS), 2000 U.S. Dist. LEXIS 12335 (S.D.N.Y. Aug. 25, 2000)",
             "Alderson v. Concordia Par. Corr. Facility, 848 F.3d 415 (5th Cir. 2017)",
         ]
         for example in simple_examples:
             extracted = get_citations(example)[0]
             error_msg = "Full span indices for a simple example should be (0, len(example)) "
-            self.assertEqual(extracted.full_span(),
-                             (0, len(example)),
-                             error_msg
-                             )
+            self.assertEqual(
+                extracted.full_span(), (0, len(example)), error_msg
+            )
         # Sentence and correct start_index
         stopword_examples = [
             ("See 66 B.U. L. Rev. 71 (1986)", 4),
-            ("Citing 66 B.U. L. Rev. 71 (1986)", 7)
+            ("Citing 66 B.U. L. Rev. 71 (1986)", 7),
         ]
         for sentence, start_idx in stopword_examples:
             extracted = get_citations(sentence)[0]
             error_msg = "Wrong span for stopword example"
-            self.assertEqual(extracted.full_span(),
-                             (start_idx, len(sentence)),
-                             error_msg
-                             )
+            self.assertEqual(
+                extracted.full_span(), (start_idx, len(sentence)), error_msg
+            )

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -711,9 +711,12 @@ class FindTest(TestCase):
         )
 
     def test_citation_fullspan(self):
-        example = 'citation number one is Wilson v. Mar. Overseas Corp., 150 F.3d 1, 6-7 ( 1st Cir. 1998); This is different from Commonwealth v. Bauer, 604 A.2d 1098 (Pa.Super. 1992), my second example'
-        extracted = get_citations(example)
+        """Check that the full_span function returns the correct indices."""
 
+        # Make sure it works with several citations in one string
+        combined_example = 'citation number one is Wilson v. Mar. Overseas Corp., 150 F.3d 1, 6-7 ( 1st Cir. 1998); This is different from Commonwealth v. Bauer, 604 A.2d 1098 (Pa.Super. 1992), my second example'
+        extracted = get_citations(combined_example)
+        # answers format is (citation_index, (full_span_start, full_span_end))
         answers = [(0, (23, 86)), (1, (111, 164))]
         for cit_idx, (start, end) in answers:
 
@@ -727,3 +730,22 @@ class FindTest(TestCase):
                 end,
                 f"full_span end index doesn't match for {extracted[cit_idx]}",
             )
+
+        # full_span should cover the whole string
+        simple_examples = [
+            '66 B.U. L. Rev. 71 (1986)',
+            '5 Minn. L. Rev. 1339, 1341 (1991)',
+            '42 U.S.C. § 405(r)(2) (2019)',
+            '37 A.L.R.4th 972, 974 (1985)',
+            '497 Fed. Appx. 274 (4th Cir. 2012)',
+            "Corp. v. Nature's Farm Prods., No. 99 Civ. 9404 (SHS), 2000 U.S. Dist. LEXIS 12335 (S.D.N.Y. Aug. 25, 2000)",
+            "Alderson v. Concordia Par. Corr. Facility, 848 F.3d 415 (5th Cir. 2017)"
+        ]
+        for example in simple_examples:
+            extracted = get_citations(example)[0]
+            print(extracted, extracted.full_span(), len(example))
+            error_msg = "Full span indices for a simple example should be (0, len(example)) "
+            self.assertEqual(extracted.full_span(),
+                             (0, len(example)),
+                             error_msg
+                             )

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -709,3 +709,21 @@ class FindTest(TestCase):
         self.run_test_pairs(
             test_pairs, "Custom tokenizer", tokenizers=[tokenizer]
         )
+
+    def test_citation_fullspan(self):
+        example = 'citation number one is Wilson v. Mar. Overseas Corp., 150 F.3d 1, 6-7 ( 1st Cir. 1998); This is different from Commonwealth v. Bauer, 604 A.2d 1098 (Pa.Super. 1992), my second example'
+        extracted = get_citations(example)
+
+        answers = [(0, (23, 86)), (1, (111, 164))]
+        for cit_idx, (start, end) in answers:
+
+            self.assertEqual(
+                extracted[cit_idx].full_span()[0],
+                start,
+                f"full_span start index doesn't match for {extracted[cit_idx]}",
+            )
+            self.assertEqual(
+                extracted[cit_idx].full_span()[1],
+                end,
+                f"full_span end index doesn't match for {extracted[cit_idx]}",
+            )


### PR DESCRIPTION
I created a new full_span() function that takes into account the whole citation (including plaintiff, defendant, and post_citation).
We still have an issue when plaintiff name is made of several words, or when the extra attribute contains too much text, but this can be solved independently.
Have a good weekend !