### PR TITLE
Issue 147, 154 - Improve citation object hashing behavior

### DIFF
--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -107,6 +107,25 @@ class CitationBase:
         from the matched text). Subclasses may override this method in order to
         specify equivalence behavior that is more appropriate for certain
         kinds of citations (e.g., see CaseCitation override).
+
+        self.groups typically contains different keys for different objects:
+
+        FullLawCitation (non-exhaustive and non-guaranteed):
+        - chapter
+        - reporter
+        - law_section
+        - issue
+        - page
+        - docket_number
+        - pamphlet
+        - title
+
+        FullJournalCitation (non-exhaustive and non-guaranteed):
+        - volume
+        - reporter
+        - page
+
+        FullCaseCitation (see CaseCitation.__hash__() notes)
         """
         return hash(
             hash_sha256(
@@ -354,6 +373,13 @@ class CaseCitation(ResourceCitation):
         """CaseCitation objects that have the same volume, reporter, and page
         are considered equivalent, unless the citation is missing a page, in
         which case the object's hash will be unique for safety.
+
+        self.groups for CaseCitation objects usually contains these keys:
+        - page (guaranteed here: https://github.com/freelawproject/reporters-db/blob/main/tests.py#L129)  # noqa: E501
+        - reporter (guaranteed here: https://github.com/freelawproject/reporters-db/blob/main/tests.py#L129)  # noqa: E501
+        - volume (almost always present, but some tax court citations don't have volumes)  # noqa: E501
+        - reporter_nominative (sometimes)
+        - volumes_nominative (sometimes)
         """
         if self.groups["page"] is None:
             return id(self)

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -361,10 +361,15 @@ class CaseCitation(ResourceCitation):
             return hash(
                 hash_sha256(
                     {
-                        "volume": self.groups["volume"],
-                        "reporter": self.corrected_reporter(),
-                        "page": self.groups["page"],
-                        "class": type(self).__name__,
+                        **{
+                            k: self.groups[k]
+                            for k in ["volume", "page"]
+                            if k in self.groups
+                        },
+                        **{
+                            "reporter": self.corrected_reporter(),
+                            "class": type(self).__name__,
+                        },
                     }
                 )
             )

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -108,8 +108,10 @@ class CitationBase:
         specify equivalence behavior that is more appropriate for certain
         kinds of citations (e.g., see CaseCitation override).
         """
-        return hash_sha256(
-            {**dict(self.groups.items()), **{"class": type(self).__name__}}
+        return hash(
+            hash_sha256(
+                {**dict(self.groups.items()), **{"class": type(self).__name__}}
+            )
         )
 
     def __eq__(self, other):
@@ -209,17 +211,19 @@ class ResourceCitation(CitationBase):
         parent class (CitationBase) objects, except that we also take into
         consideration the all_editions field.
         """
-        return hash_sha256(
-            {
-                **dict(self.groups.items()),
-                **{
-                    "all_editions": sorted(
-                        [asdict(e) for e in self.all_editions],
-                        key=lambda d: d["short_name"],  # type: ignore
-                    ),
-                    "class": type(self).__name__,
-                },
-            }
+        return hash(
+            hash_sha256(
+                {
+                    **dict(self.groups.items()),
+                    **{
+                        "all_editions": sorted(
+                            [asdict(e) for e in self.all_editions],
+                            key=lambda d: d["short_name"],  # type: ignore
+                        ),
+                        "class": type(self).__name__,
+                    },
+                }
+            )
         )
 
     @dataclass(eq=True, unsafe_hash=True)
@@ -354,13 +358,15 @@ class CaseCitation(ResourceCitation):
         if self.groups["page"] is None:
             return id(self)
         else:
-            return hash_sha256(
-                {
-                    "volume": self.groups["volume"],
-                    "reporter": self.corrected_reporter(),
-                    "page": self.groups["page"],
-                    "class": type(self).__name__,
-                }
+            return hash(
+                hash_sha256(
+                    {
+                        "volume": self.groups["volume"],
+                        "reporter": self.corrected_reporter(),
+                        "page": self.groups["page"],
+                        "class": type(self).__name__,
+                    }
+                )
             )
 
     @dataclass(eq=True, unsafe_hash=True)
@@ -701,11 +707,13 @@ class Resource(ResourceType):
         NOT considered the same, even if their other attributes are identical.
         This is to avoid potential false positives.
         """
-        return hash_sha256(
-            {
-                "citation": hash(self.citation),
-                "class": type(self).__name__,
-            }
+        return hash(
+            hash_sha256(
+                {
+                    "citation": hash(self.citation),
+                    "class": type(self).__name__,
+                }
+            )
         )
 
     def __eq__(self, other):

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -60,7 +60,7 @@ class Edition:
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=False, unsafe_hash=False)
 class CitationBase:
     """Base class for objects returned by `eyecite.find.get_citations`. We
     define several subclasses of this class below, representing the various
@@ -101,20 +101,28 @@ class CitationBase:
             + ")"
         )
 
+    def __hash__(self) -> int:
+        """In general, citations are considered equivalent if they have the
+        same group values (i.e., the same regex group content that is extracted
+        from the matched text). Subclasses may override this method in order to
+        specify equivalence behavior that is more appropriate for certain
+        kinds of citations (e.g., see CaseCitation override).
+        """
+        return hash((type(self), tuple(self.groups.items())))
+
+    def __eq__(self, other):
+        """This method is inherited by all subclasses and should not be
+        overridden. It implements object equality in exactly the same way as
+        defined in an object's __hash__() function, which should be overridden
+        instead if desired.
+        """
+        return self.__hash__() == other.__hash__()
+
     @dataclass(eq=True, unsafe_hash=True)
     class Metadata:
         """Define fields on self.metadata."""
 
         parenthetical: Optional[str] = None
-
-    def comparison_hash(self) -> int:
-        """Return hash that will be the same if two cites are semantically
-        equivalent, unless the citation is a CaseCitation missing a page.
-        """
-        if isinstance(self, CaseCitation) and self.groups["page"] is None:
-            return id(self)
-        else:
-            return hash((type(self), tuple(self.groups.items())))
 
     def corrected_citation(self):
         """Return citation with any variations normalized."""
@@ -170,7 +178,7 @@ class CitationBase:
         return start, end
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class ResourceCitation(CitationBase):
     """Base class for a case, law, or journal citation. Could be short or
     long."""
@@ -194,17 +202,19 @@ class ResourceCitation(CitationBase):
         )
         super().__post_init__()
 
+    def __hash__(self) -> int:
+        """ResourceCitation objects are hashed in the same way as their
+        parent class (CitationBase) objects, except that we also take into
+        consideration the all_editions field.
+        """
+        return hash((super().__hash__(), self.all_editions))
+
     @dataclass(eq=True, unsafe_hash=True)
     class Metadata(CitationBase.Metadata):
         """Define fields on self.metadata."""
 
         pin_cite: Optional[str] = None
         year: Optional[str] = None
-
-    def comparison_hash(self) -> int:
-        """Return hash that will be the same if two cites are semantically
-        equivalent."""
-        return hash((super().comparison_hash(), self.all_editions))
 
     def add_metadata(self, words: "Tokens"):
         """Extract metadata from text before and after citation."""
@@ -248,13 +258,13 @@ class ResourceCitation(CitationBase):
             self.edition_guess = editions[0]
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class FullCitation(ResourceCitation):
     """Abstract base class indicating that a citation fully identifies a
     resource."""
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class FullLawCitation(FullCitation):
     """Citation to a source from `reporters_db/laws.json`."""
 
@@ -291,7 +301,7 @@ class FullLawCitation(FullCitation):
         return "".join(parts)
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class FullJournalCitation(FullCitation):
     """Citation to a source from `reporters_db/journals.json`."""
 
@@ -317,11 +327,30 @@ class FullJournalCitation(FullCitation):
         return "".join(parts)
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class CaseCitation(ResourceCitation):
     """Convenience class which represents a single citation found in a
     document.
     """
+
+    def __hash__(self) -> int:
+        """CaseCitation objects that have the same volume, reporter, and page
+        are considered equivalent, unless the citation is missing a page, in
+        which case the object's hash will be unique for safety.
+        """
+        if self.groups["page"] is None:
+            return id(self)
+        else:
+            return hash(
+                (
+                    type(self),
+                    frozenset({
+                        'volume': self.groups["volume"],
+                        'reporter': self.corrected_reporter(),
+                        'page': self.groups["page"]
+                    }.items()),
+                )
+            )
 
     @dataclass(eq=True, unsafe_hash=True)
     class Metadata(FullCitation.Metadata):
@@ -339,7 +368,7 @@ class CaseCitation(ResourceCitation):
             self.metadata.court = "scotus"
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class FullCaseCitation(CaseCitation, FullCitation):
     """Convenience class which represents a standard, fully named citation,
     i.e., the kind of citation that marks the first time a document is cited.
@@ -389,7 +418,7 @@ class FullCaseCitation(CaseCitation, FullCitation):
         return "".join(parts)
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class ShortCaseCitation(CaseCitation):
     """Convenience class which represents a short form citation, i.e., the kind
     of citation made after a full citation has already appeared. This kind of
@@ -419,7 +448,7 @@ class ShortCaseCitation(CaseCitation):
         return "".join(parts)
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class SupraCitation(CitationBase):
     """Convenience class which represents a 'supra' citation, i.e., a citation
     to something that is above in the document. Like a short form citation,
@@ -458,7 +487,7 @@ class SupraCitation(CitationBase):
         return "".join(parts)
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class IdCitation(CitationBase):
     """Convenience class which represents an 'id' or 'ibid' citation, i.e., a
     citation to the document referenced immediately prior. An 'id' citation is
@@ -468,6 +497,10 @@ class IdCitation(CitationBase):
 
     Example: "... foo bar," id., at 240
     """
+
+    def __hash__(self) -> int:
+        """IdCitation objects are always considered unique for safety."""
+        return id(self)
 
     @dataclass(eq=True, unsafe_hash=True)
     class Metadata(CitationBase.Metadata):
@@ -483,13 +516,17 @@ class IdCitation(CitationBase):
         return "".join(parts)
 
 
-@dataclass(eq=True, unsafe_hash=True, repr=False)
+@dataclass(eq=False, unsafe_hash=False, repr=False)
 class UnknownCitation(CitationBase):
     """Convenience class which represents an unknown citation. A recognized
     citation should theoretically be parsed as a CaseCitation, FullLawCitation,
     or a FullJournalCitation. If it's something else, this class serves as
     a naive catch-all.
     """
+
+    def __hash__(self) -> int:
+        """UnknownCitation objects are always considered unique for safety."""
+        return id(self)
 
 
 def NonopinionCitation(*args, **kwargs):
@@ -647,13 +684,13 @@ class Resource(ResourceType):
 
     def __hash__(self):
         """Resources are the same if their citations are semantically
-        equivalent.
+        equivalent, as defined by their hash function.
 
         Note: Resources composed of citations with missing page numbers are
         NOT considered the same, even if their other attributes are identical.
         This is to avoid potential false positives.
         """
-        return self.citation.comparison_hash()
+        return hash(self.citation)
 
     def __eq__(self, other):
         return self.__hash__() == other.__hash__()

--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -67,8 +67,8 @@ def case_citation(
 
 
 def law_citation(
-    source_text,
-    reporter,
+    source_text=None,
+    reporter="Mass. Gen. Laws",
     **kwargs,
 ):
     """Convenience function for creating mock FullLawCitation objects."""

--- a/eyecite/utils.py
+++ b/eyecite/utils.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import re
-from ctypes import c_int32
 
 from lxml import etree
 
@@ -128,7 +127,5 @@ def hash_sha256(dictionary: dict) -> int:
     # Convert the JSON string to bytes
     json_bytes: bytes = json_str.encode("utf-8")
 
-    # Calculate the hash of the bytes, convert to 32-bit int, and return
-    return c_int32(
-        int.from_bytes(hashlib.sha256(json_bytes).digest(), byteorder="big")
-    ).value
+    # Calculate the hash of the bytes, convert to an int, and return
+    return int.from_bytes(hashlib.sha256(json_bytes).digest(), byteorder="big")

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -123,6 +123,19 @@ class ModelsTest(TestCase):
         self.assertNotEqual(hash(citations[0]), hash(citations[1]))
         print("✓")
 
+    def test_tax_court_citation_comparison(self):
+        """Are two citation objects equal when their attributes are
+        the same, even if they are tax court citations and might not
+        have volumes?"""
+        citations = [
+            get_citations("T.C.M. (RIA) ¶ 95,342")[0],
+            get_citations("T.C.M. (RIA) ¶ 95,342")[0],
+        ]
+        print("Testing tax court citation comparison...", end=" ")
+        self.assertEqual(citations[0], citations[1])
+        self.assertEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")
+
     def test_id_citation_comparison(self):
         """Are two IdCitation objects always different?"""
         citations = [

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -162,19 +162,19 @@ class ModelsTest(TestCase):
         objects = [
             (
                 case_citation(),
-                1009797070,
+                376794172219282606,
             ),
             (
                 journal_citation(),
-                -1332833206,
+                1073308118601601409,
             ),
             (
                 law_citation(),
-                554454242,
+                407008277458283218,
             ),
             (
                 Resource(case_citation()),
-                -666984820,
+                1986750081022884797,
             ),
         ]
         for citation, citation_hash in objects:

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -2,21 +2,28 @@ from unittest import TestCase
 
 from eyecite import get_citations
 from eyecite.models import Resource
-from eyecite.test_factories import case_citation
+from eyecite.test_factories import (
+    case_citation,
+    id_citation,
+    journal_citation,
+    law_citation,
+    unknown_citation,
+)
 
 
 class ModelsTest(TestCase):
     def test_citation_comparison(self):
         """Are two citation objects equal when their attributes are
         the same?"""
-        citations = [
-            case_citation(2, volume="2", reporter="U.S.", page="2"),
-            case_citation(2, volume="2", reporter="U.S.", page="2"),
-        ]
-        print("Testing citation comparison...", end=" ")
-        self.assertEqual(citations[0], citations[1])
-        self.assertEqual(hash(citations[0]), hash(citations[1]))
-        print("✓")
+        for factory in [case_citation, journal_citation, law_citation]:
+            citations = [
+                factory(),
+                factory(),
+            ]
+            print(f"Testing {factory.__name__} comparison...", end=" ")
+            self.assertEqual(citations[0], citations[1])
+            self.assertEqual(hash(citations[0]), hash(citations[1]))
+            print("✓")
 
     def test_resource_comparison(self):
         """Are two Resource objects equal when their citations' attributes are
@@ -42,6 +49,18 @@ class ModelsTest(TestCase):
         self.assertNotEqual(hash(citations[0]), hash(citations[1]))
         print("✓")
 
+    def test_citation_comparison_with_missing_page_cites(self):
+        """Are two citation objects different when one of them is missing
+        a page, even if their other attributes are the same?"""
+        citations = [
+            case_citation(2, volume="2", reporter="U.S.", page="__"),
+            case_citation(2, volume="2", reporter="U.S.", page="__"),
+        ]
+        print("Testing citation comparison with missing pages...", end=" ")
+        self.assertNotEqual(citations[0], citations[1])
+        self.assertNotEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")
+
     def test_citation_comparison_with_corrected_reporter(self):
         """Are two citation objects equal when their attributes are
         the same, even if the reporter has been normalized?"""
@@ -54,6 +73,62 @@ class ModelsTest(TestCase):
         )
         self.assertEqual(citations[0], citations[1])
         self.assertEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")
+
+    def test_citation_comparison_with_different_source_text(self):
+        """Are two citation objects equal when their attributes are
+        the same, even if they have different source text?"""
+        citations = [
+            case_citation(
+                source_text="foobar", volume="2", reporter="U.S.", page="4"
+            ),
+            case_citation(
+                source_text="foo", volume="2", reporter="U.S.", page="4"
+            ),
+        ]
+        print(
+            "Testing citation comparison with different source text...",
+            end=" ",
+        )
+        self.assertEqual(citations[0], citations[1])
+        self.assertEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")
+
+    def test_citation_comparison_with_different_reporter(self):
+        """Are two citation objects different when they have different
+        reporters, even if their other attributes are the same?
+        (sanity check)"""
+        citations = [
+            case_citation(2, volume="2", reporter="F. Supp.", page="4"),
+            case_citation(2, volume="2", reporter="U. S.", page="4"),
+        ]
+        print(
+            "Testing citation comparison with different reporters...", end=" "
+        )
+        self.assertNotEqual(citations[0], citations[1])
+        self.assertNotEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")
+
+    def test_id_citation_comparison(self):
+        """Are two IdCitation objects always different?"""
+        citations = [
+            id_citation("Id.,", metadata={"pin_cite": "at 123"}),
+            id_citation("Id.,", metadata={"pin_cite": "at 123"}),
+        ]
+        print("Testing id citation comparison...", end=" ")
+        self.assertNotEqual(citations[0], citations[1])
+        self.assertNotEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")
+
+    def test_unknown_citation_comparison(self):
+        """Are two UnknownCitation objects always different?"""
+        citations = [
+            unknown_citation("§99"),
+            unknown_citation("§99"),
+        ]
+        print("Testing unknown citation comparison...", end=" ")
+        self.assertNotEqual(citations[0], citations[1])
+        self.assertNotEqual(hash(citations[0]), hash(citations[1]))
         print("✓")
 
     def test_missing_page_cite_conversion(self):

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -141,3 +141,37 @@ class ModelsTest(TestCase):
         self.assertIsNone(citation1.groups["page"])
         self.assertIsNone(citation2.groups["page"])
         print("✓")
+
+    def test_persistent_hash(self):
+        """Are object hashes reproducible across runs?"""
+        print("Testing persistent citation hash...", end=" ")
+        objects = [
+            (
+                case_citation(),
+                1009797070,
+            ),
+            (
+                journal_citation(),
+                -1332833206,
+            ),
+            (
+                law_citation(),
+                554454242,
+            ),
+            (
+                Resource(case_citation()),
+                -666984820,
+            ),
+        ]
+        for citation, citation_hash in objects:
+            self.assertEqual(hash(citation), citation_hash)
+            print("✓")
+
+    def test_hash_function_identity(self):
+        """Do hash() and __hash__() output the same hash?"""
+        citation = case_citation()
+        resource = Resource(case_citation())
+        print("Testing hash function identity...", end=" ")
+        self.assertEqual(hash(citation), citation.__hash__())
+        self.assertEqual(hash(resource), resource.__hash__())
+        print("✓")

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -42,6 +42,20 @@ class ModelsTest(TestCase):
         self.assertNotEqual(hash(citations[0]), hash(citations[1]))
         print("✓")
 
+    def test_citation_comparison_with_corrected_reporter(self):
+        """Are two citation objects equal when their attributes are
+        the same, even if the reporter has been normalized?"""
+        citations = [
+            case_citation(2, volume="2", reporter="U.S.", page="4"),
+            case_citation(2, volume="2", reporter="U. S.", page="4"),
+        ]
+        print(
+            "Testing citation comparison with corrected reporter...", end=" "
+        )
+        self.assertEqual(citations[0], citations[1])
+        self.assertEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")
+
     def test_missing_page_cite_conversion(self):
         """Do citations with missing page numbers get their groups['page']
         attribute set to None?"""

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -94,6 +94,20 @@ class ModelsTest(TestCase):
         self.assertEqual(hash(citations[0]), hash(citations[1]))
         print("✓")
 
+    def test_citation_comparison_with_nominative_reporter(self):
+        """Are two citation objects equal when their attributes are
+        the same, even if one of them has a nominative reporter?"""
+        citations = [
+            get_citations("5 U.S. 137")[0],
+            get_citations("5 U.S. (1 Cranch) 137")[0],
+        ]
+        print(
+            "Testing citation comparison with nominative reporter...", end=" "
+        )
+        self.assertEqual(citations[0], citations[1])
+        self.assertEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")
+
     def test_citation_comparison_with_different_reporter(self):
         """Are two citation objects different when they have different
         reporters, even if their other attributes are the same?


### PR DESCRIPTION
This PR does three things:
1) Citations with normalized/corrected reporters (e.g., `1 U.S. 1` versus `1 U. S. 1`) are now treated as equal (#147)
2) Citations with nominative reporters (e.g., `5 U.S. 137` versus `5 U.S. (1 Cranch) 137` are now treated as equal (#154)
3) Citation hashes are now reproducible/deterministic across runs (https://github.com/freelawproject/eyecite/issues/147#issuecomment-1488381874)

In terms of implementation, here's what's changed:
- The old `comparison_hash()` method that a few classes had has been removed entirely. This was originally intended to essentially be a private method for `Resource` objects to call, but the name was confusing and could have been misinterpreted by a causal user as a public method that should be used for general comparisons. Going forward, anyone should simply use the built-in `hash()` method for everything, which is the most natural approach anyway.
- `CitationBase` classes and their subclasses now all use the `@dataclass(eq=False, unsafe_hash=False)` decorator. Previously both `eq` and `unsafe_hash` were set to `True`. As the keyword argument implies, this was somewhat... unsafe. Or at least confusing. See [here](https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass) for a detailed discussion explaining how dataclass objects automatically try to create hash functions when these arguments are `True`. I have changed this so none of this implicit stuff is happening anymore; instead, we explicitly define `__eq__()` and `__hash__()` ourselves on the `CitationBase` class, which creates a clear record of how the hashing is actually happening. (These methods are then inherited by the citation subclasses, though `ResourceCitation` and `CaseCitation` classes override the `__hash__()` method in order to maintain conformity with existing behavior for those special cases.
- To create persistent hashes, I use `hashlib.sha256`. However, the built-in `hash()` function will only output hashes that are 32 bits long, so I truncate the sha256 hash using `c_int32()` from the `ctypes` standard library. By doing this truncation ourselves, we ensure that calling `hash(obj)` and `obj.__hash__()` both return the same hash (for a given object).
- This behavior was not previously well-defined, but I have made it so `IdCitation` and `UnknownCitation` objects are sui generis. Since we don't really know anything about what these objects point to, I think it would be dangerous to ever hash two of them the same.

If merged, this PR supersedes #148. Sorry again @overmode for the previous confusion, this turned out to be quite complicated. I have used some of your logic and tests in this PR, and it should achieve all the functionality you were looking for.

Feedback welcome!