### PR TITLE
Implement NonopinionCitation deprecation plan (#110)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Features:
 - None
 
 Changes:
-- None
+- As noted in 2.3.3 (2021-03-23), the old `NonopinionCitation` class was renamed `UnknownCitation` to better reflect its purpose. Support for the old class name has now been completely deprecated. This change is purely semantic -- there is no change in how these citations are handled.
 
 Fixes:
 - None

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -492,17 +492,6 @@ class UnknownCitation(CitationBase):
     """
 
 
-def NonopinionCitation(*args, **kwargs):
-    from warnings import warn
-
-    warn(
-        """NonopinionCitation will be deprecated in eyecite 2.5.0.
-        Please use UnknownCitation instead.""",
-        DeprecationWarning,
-    )
-    return UnknownCitation(*args, **kwargs)
-
-
 @dataclass(eq=True, unsafe_hash=True)
 class Token(UserString):
     """Base class for special tokens. For performance, this isn't used

--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -103,17 +103,6 @@ def unknown_citation(source_text=None, index=0, **kwargs):
     return UnknownCitation(SectionToken(source_text, 0, 99), index, **kwargs)
 
 
-def nonopinion_citation(*args, **kwargs):
-    from warnings import warn
-
-    warn(
-        """nonopinion_citation() will be deprecated in eyecite 2.5.0.
-        Please use unknown_citation() instead.""",
-        DeprecationWarning,
-    )
-    return unknown_citation(*args, **kwargs)
-
-
 def supra_citation(source_text=None, index=0, **kwargs):
     """Convenience function for creating mock SupraCitation objects."""
     return SupraCitation(SupraToken(source_text, 0, 99), index, **kwargs)


### PR DESCRIPTION
In #110, eighteen months ago, we renamed `NonopinionCitation` to `UnknownCitation` and implemented a deprecation warning signaling that support for the old object would end in version 2.5.0. We're now on 2.5.2, so I think it is safe to remove this old code.