### PR TITLE
Update CHANGES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,26 +16,42 @@ Fixes:
 
 ## Current
 
-**2.5.5 - 2024-01-10**
+**2.6.0 - 2024-02-07**
 
-Fixes:
- - 
+Features:
+
+ - Removes Python 3.8 and 3.9 support
+ - Adds Python 3.12 support
 
 Changes:
- - Update dependencies
+
+- The hashing and equality behavior of `CitationBase` objects has changed in subtle ways in order to conform with user intuitions and define previously ill-defined behavior. Most importantly, to compare two `eyecite` objects going forward, simply use the native Python syntax `citation1 == citation2`. You can also take the hash of each object and compare that with identical results: `hash(citation1) == hash(citation2)`. This broad change has several more specific implications:
+  - Citation objects that are created from text with a normalized/corrected reporter are now treated as equal to objects created from text *without* a normalized/corrected reporter (e.g., `1 U.S. 1` versus `1 U. S. 1` are now treated as equal)
+  - Citation objects that are created from text with a nominative reporter are now treated as equal to objects created from text *without* a nominative reporter (e.g., `5 U.S. 137` versus `5 U.S. (1 Cranch) 137` are now treated as equal)
+  - Any `IdCitation` and `UnknownCitation` object will always be treated as unequal to any other object
+  - Previously, `CitationBase` objects had a `comparison_hash()` method. This method was never intended to be a "public" method and has been removed.
+  - Citation hashes are now stable and reproducible across module loadings of `eyecite`, as we are now using `hashlib.sha256` under the hood. However, note that due to `hashlib`'s implementation details, hashes with NOT be consistent across 32 and 64 machines.
+
+- As noted in 2.3.3 (2021-03-23), the old `NonopinionCitation` class was renamed `UnknownCitation` to better reflect its purpose. Support for the old class name has now been completely deprecated. This change is purely semantic -- there is no change in how these citations are handled.
+
+Fixes:
+
+ - Update dependencies for reporters-db
 
 
 ## Past
 
-## Current
+**2.5.5 - 2024-01-10**
+
+Yanked.
 
 **2.5.4 - 2024-01-10**
 
-Fixes:
- - Update dependencies for reporters-db
+Yanked.
 
-Changes:
-- As noted in 2.3.3 (2021-03-23), the old `NonopinionCitation` class was renamed `UnknownCitation` to better reflect its purpose. Support for the old class name has now been completely deprecated. This change is purely semantic -- there is no change in how these citations are handled.
+**2.5.3 - 2024-01-10**
+
+Yanked.
 
 **2.5.2 - 2023-05-23**
 


### PR DESCRIPTION
I just noticed that @flooie did a couple of new releases a few weeks ago (dd9472c9f5184efaaf964df3752e686cb2f19f73 and 2cbe140119559b43b571f65c40a2b7ddb618f4c6). Unfortunately, due to my own negligence, I never updated the CHANGES file to reflect my hashing changes in #155.

This PR memorializes those changes in the CHANGES file (and also adds a line about the changed Python support) by *backdating* them into version `2.5.4`. This might be fine, but it also puts us in the slightly awkward position of having pushed a "patch" version that actually contains some more fundamental changes. Ideally, I think it would have been best to have released version `2.6.0`. (To be clear, this is my own fault  because I never put the changes in the CHANGES.) However, at this point, I'm not sure the best way to proceed? One option is to just merge this PR as-is; the other option would be to also push a minor version update for clarity, though the changes are already baked-in to the previous patch version?