### PR TITLE
chore(workflow): Updates the pdoc.yml to fix the deploy step

### DIFF
--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -52,7 +52,7 @@ jobs:
           sed -i 's/AhocorasickTokenizer(.*\]))/AhocorasickTokenizer()/' ./eyecite/index.html
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.5.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: api_documentation/eyecite


### PR DESCRIPTION
This PR updates the pdoc.yml file to change the name of the action of the deploy step. It should be `JamesIves/github-pages-deploy-action@v4` according to the [documentation](https://github.com/JamesIves/github-pages-deploy-action?tab=readme-ov-file#getting-started-airplane), but we're using `jamesIves/github-pages-deploy-action@4.5.0 `instead.