### PR TITLE
chore(workflow): Downgrade the python version in the pdoc action

### DIFF
--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1.3.4


### PR DESCRIPTION
There is a [known issue with pdoc3](https://github.com/pdoc3/pdoc/issues/392#issuecomment-1872475490) that prevents it from functioning correctly with Python 3.12. When attempting to execute the command `pdoc module`, the following error occurs: `ModuleNotFoundError: No module named 'distutils'`. 

As a workaround, temporarily downgrading the python version within the action to `3.11` should allow it to complete successfully.