### PR TITLE
fix(model): Tweaks the corrected_citation_full method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
 - None
 
 Fixes:
-- None
+- Adds missing closing parentheses to the corrected_citation_full method in FullCaseCitation and FullJournalCitation classes.
 
 
 ## Current

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -359,7 +359,7 @@ class FullJournalCitation(FullCitation):
         if m.pin_cite:
             parts.append(f", {m.pin_cite}")
         if m.year:
-            parts.append(f" ({m.year}")
+            parts.append(f" ({m.year})")
         if m.parenthetical:
             parts.append(f" ({m.parenthetical})")
         return "".join(parts)
@@ -462,7 +462,7 @@ class FullCaseCitation(CaseCitation, FullCitation):
             parts.append(m.extra)
         publisher_date = " ".join(i for i in (m.court, m.year) if i)
         if publisher_date:
-            parts.append(f" ({publisher_date}")
+            parts.append(f" ({publisher_date})")
         if m.parenthetical:
             parts.append(f" ({m.parenthetical})")
         return "".join(parts)

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -202,3 +202,22 @@ class ModelsTest(TestCase):
         self.assertEqual(hash(citation), citation.__hash__())
         self.assertEqual(hash(resource), resource.__hash__())
         print("✓")
+
+    def test_corrected_full_citation_includes_closing_parenthesis(self):
+        """Does the corrected_citation_full method return a properly formatted
+        citation?"""
+        journal_citation = get_citations(
+            "Originalism without Foundations, 65 N.Y.U. L. Rev. 1373 (1990)"
+        )[0]
+        self.assertEqual(
+            journal_citation.corrected_citation_full(),
+            "65 N.Y.U. L. Rev. 1373 (1990)",
+        )
+
+        full_case_citation = get_citations(
+            "Meritor Sav. Bank v. Vinson, 477 U.S. 57, 60 (1986)"
+        )[0]
+        self.assertEqual(
+            full_case_citation.corrected_citation_full(),
+            "Bank v. Vinson, 477 U.S. 57, 60 (scotus 1986)",
+        )


### PR DESCRIPTION
This PR adds missing closing parentheses to the `corrected_citation_full` method in `FullCaseCitation` and `FullJournalCitation` classes. Additionally, I've added a test to prevent similar issues in the future.