### PR TITLE
fix(hyperscan): Handles the InvalidError exception during db loading.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
 - None
 
 Fixes:
-- None
+- Strengthens error handling during the loading of the cached Hyperscan database. This ensures that an invalid cache triggers a rebuild.
 
 
 ## Current

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -528,6 +528,12 @@ class HyperscanTokenizer(Tokenizer):
                         )
                     except TypeError:
                         hyperscan_db = hyperscan.loadb(cache_bytes)
+                    except hyperscan.InvalidError:
+                        # Skipping hyperscan_db assignment to force a full
+                        # database recompile as the cached version seems to be
+                        # invalid.
+                        pass
+
                     try:
                         # at some point Scratch became necessary --
                         # https://github.com/darvid/python-hyperscan/issues/50#issuecomment-1386243477


### PR DESCRIPTION
This PR introduces logic to handle the `InvalidError` exception during loading the cached hyperscan db and fixes [#4053](https://github.com/freelawproject/courtlistener/issues/4053). 

According to the documentation, this error (`InvalidError`) is only returned when the function detects an invalid parameter. Since `loaddb` only takes one parameter(the serialized Hyperscan database), this error indicates a problem with the input ByteString. The current fix addresses this by triggering a full database recompile whenever this exception is encountered.