### PR TITLE
ShortCaseCitation.full_span now includes parentheticals

### DIFF
--- a/eyecite/find.py
+++ b/eyecite/find.py
@@ -175,7 +175,7 @@ def _extract_shortform_citation(
 
     # Get pin_cite
     cite_token = cast(CitationToken, words[index])
-    pin_cite, span_end, parenthetical = extract_pin_cite(
+    pin_cite, span_end, full_span_end, parenthetical = extract_pin_cite(
         words, index, prefix=cite_token.groups["page"]
     )
 
@@ -186,6 +186,12 @@ def _extract_shortform_citation(
         exact_editions=cite_token.exact_editions,
         variation_editions=cite_token.variation_editions,
         span_end=span_end,
+        full_span_start=(
+            index
+            if not antecedent_guess
+            else index - 1 + m.start()
+        ),
+        full_span_end=full_span_end,
         metadata={
             "antecedent_guess": antecedent_guess,
             "pin_cite": pin_cite,
@@ -212,7 +218,7 @@ def _extract_supra_citation(
     Supra 3: Adarand, supra, somethingelse
     Supra 4: Adrand, supra. somethingelse
     """
-    pin_cite, span_end, parenthetical = extract_pin_cite(words, index)
+    pin_cite, span_end, full_span_end, parenthetical = extract_pin_cite(words, index)
     antecedent_guess = None
     volume = None
     m = match_on_tokens(
@@ -231,6 +237,12 @@ def _extract_supra_citation(
         cast(SupraToken, words[index]),
         index,
         span_end=span_end,
+        full_span_start=(
+            index
+            if not antecedent_guess
+            else index - 1 + m.start()
+        ),
+        full_span_end=full_span_end,
         metadata={
             "antecedent_guess": antecedent_guess,
             "pin_cite": pin_cite,
@@ -248,11 +260,12 @@ def _extract_id_citation(
     immediately succeeding tokens to construct and return an IdCitation
     object.
     """
-    pin_cite, span_end, parenthetical = extract_pin_cite(words, index)
+    pin_cite, span_end, full_span_end, parenthetical = extract_pin_cite(words, index)
     return IdCitation(
         cast(IdToken, words[index]),
         index,
         span_end=span_end,
+        full_span_end=full_span_end,
         metadata={
             "pin_cite": pin_cite,
             "parenthetical": parenthetical,

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -233,6 +233,7 @@ def extract_pin_cite(
         return (
             pin_cite,
             from_token.end + extra_chars - len(prefix),
+            from_token.end + m.end(),
             parenthetical,
         )
     return None, None, None


### PR DESCRIPTION
Previously, only `FullCaseCitation` objects included parentheticals and antecedent text in the `full_span` method.

For example, in this `ShortCaseCitation`:

```python
>>> test_sentence = "See Sargent, 75 F.3d at 89 (explaining that blah blah blah)."
>>> eyecite.get_citations(test_sentence)[0].full_span()
(13, 26)
```

However, if the same citation was a `FullCaseCitation`, what is included differs:

```python
>>> test_sentence = "See Sargent v. Columbia Forest Prods., 75 F.3d 86 (2d Cir. 1996) (explaining that blah blah blah)."
>>> eyecite.get_citations(test_sentence)[0].full_span()
(4, 97)
```

I am working in an application that requires all `full_span` definitions to be more like the latter, so I've made a small set of changes to `ShortCaseCitation`, `IdCitation`, and `SupraCitation`.

No existing tests are broken by the changes, but I have not written new tests for the behavior.

If this is desired behavior; that is, if it would be helpful to harmonize these definitions by always including the parenthetical and antecedent, I can write some tests and clean this up a bit into a PR. Let me know if that would be helpful.