### PR TITLE
Short cite regex bug

### DIFF
--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -21,22 +21,7 @@ def short_cite_re(regex):
     """Convert a full citation regex into a short citation regex.
     Currently this just means we turn '(?P<reporter>...),? (?P<page>...'
     to '(?P<reporter>...),? at (?P<page>...'"""
-    return re.sub(
-        r"""
-            # reporter group:
-            (
-                \(\?P<reporter>[^)]+\)
-            )
-            (?:,\?)?\  # comma and space
-            # page group:
-            (
-                \(\?P<page>
-            )
-        """,
-        r"\1,? at \2",
-        regex,
-        flags=re.VERBOSE,
-    )
+    return regex.replace("(?P<page>", "at (?P<page>")
 
 
 # *** Tokenizer regexes: ***

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -1,5 +1,4 @@
 # *** Helpers for building regexes: ***
-import regex as re
 
 
 def space_boundaries_re(regex):

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -120,7 +120,7 @@ class FindTest(TestCase):
             # can we handle variations with parenthesis
             ('1 So.2d at 1',
              [case_citation(volume="1", reporter="So.2d", page="1", short=True,
-                 metadata={'pin_cite': '1'})]),
+              metadata={'pin_cite': '1'})]),
             # Test with court and extra information
             ('bob lissner v. test 1 U.S. 12, 347-348 (4th Cir. 1982)',
              [case_citation(page='12', year=1982,

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -117,6 +117,10 @@ class FindTest(TestCase):
              [case_citation(metadata={'plaintiff': 'lissner',
                                       'defendant': 'test'},
                             year=1982)]),
+            # can we handle variations with parenthesis
+            ('1 So.2d at 1',
+             [case_citation(volume="1", reporter="So.2d", page="1", short=True,
+                 metadata={'pin_cite': '1'})]),
             # Test with court and extra information
             ('bob lissner v. test 1 U.S. 12, 347-348 (4th Cir. 1982)',
              [case_citation(page='12', year=1982,


### PR DESCRIPTION
Fix for #213 

Eyecite had a bug that could not generate short cite regex patterns for non standard regex variations.  

Anything with content between reporter and page,
Anything with parenthesis in the reporter all caused failures.  

This affected possibly 1537 variants.   
