### PR TITLE
fix(loggers): name loggers and demote errors to warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Features:
 - None
 
 Changes:
-- None
+- Name loggers with `__name__` and demote errors to warnings
 
 Fixes:
 - Strengthens error handling during the loading of the cached Hyperscan database. This ensures that an invalid cache triggers a rebuild.

--- a/eyecite/annotate.py
+++ b/eyecite/annotate.py
@@ -12,7 +12,7 @@ from eyecite.utils import (
     wrap_html_tags,
 )
 
-logger = getLogger("eyecite")
+logger = getLogger(__name__)
 
 
 def annotate_citations(
@@ -107,7 +107,7 @@ def annotate_citations(
                     start, end, plain_text
                 )
                 if not is_balanced_html(span_text):
-                    logger.error(
+                    logger.warning(
                         "Citation was not annotated due to unbalanced tags %s",
                         original_span_text,
                     )

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -28,7 +28,7 @@ from eyecite.regexes import (
     YEAR_REGEX,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 BACKWARD_SEEK = 28  # Median case name length in the CL db is 28 (2016-02-26)
 
@@ -410,7 +410,7 @@ def filter_citations(citations: List[CitationBase]) -> List[CitationBase]:
                 isinstance(citation, FullCaseCitation)
                 and isinstance(last_citation, FullCaseCitation)
             ):
-                logger.error(
+                logger.warning(
                     "Unknown overlap case. Last cite: %s. Current: %s",
                     last_citation,
                     citation,


### PR DESCRIPTION
This has been spamming Sentry in courtlistener; one of the loggers was unnamed, and thus the root logger; the other was named but still got propagated.

The log level should had been a warning; since for now they have development and debugging purposes