### PR TITLE
fix(utils.maybe_balance_style_tags): use re.escape to form regex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,16 +16,15 @@ Fixes:
 
 ## Current
 
+**2.6.11 - 2025-02-20**
+
+Fixes:
+- Add regex escapig to `utils.maybe_balance_style_tags`
+
 **2.6.10 - 2025-02-20**
 
 Features:
 - Adds support to correct citation page
-
-Changes:
-- None
-
-Fixes:
-- None
 
 ## Past
 

--- a/eyecite/utils.py
+++ b/eyecite/utils.py
@@ -288,7 +288,7 @@ def maybe_balance_style_tags(
                 end + len(closing_tag) + tolerance, len(plain_text)
             )
             if end_match := re.search(
-                rf"{span_text}\s*{closing_tag}",
+                rf"{re.escape(span_text)}\s*{re.escape(closing_tag)}",
                 plain_text[start:extended_end],
                 flags=re.MULTILINE,
             ):
@@ -298,7 +298,7 @@ def maybe_balance_style_tags(
             # look for opening tag before the start
             extended_start = min(start - len(opening_tag) - tolerance, 0)
             if start_match := re.search(
-                rf"{opening_tag}\s*{span_text}",
+                rf"{re.escape(opening_tag)}\s*{re.escape(span_text)}",
                 plain_text[extended_start:end],
                 flags=re.MULTILINE,
             ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-version = "2.6.10"
+version = "2.6.11"
 authors = ["Free Law Project <info@free.law>"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/tests/test_AnnotateTest.py
+++ b/tests/test_AnnotateTest.py
@@ -1,7 +1,9 @@
+import re
 from pathlib import Path
 from unittest import TestCase
 
 from eyecite import annotate_citations, clean_text, get_citations
+from eyecite.utils import maybe_balance_style_tags
 
 
 class AnnotateTest(TestCase):
@@ -229,6 +231,14 @@ class AnnotateTest(TestCase):
                     **annotate_kwargs,
                 )
                 self.assertEqual(annotated, expected)
+
+    def test_tag_balancing(self):
+        """Test trickier tag balancing cases"""
+        string = "Something; In <em>Nobelman </em> at 332, 113 S.Ct. 2106 (2010); Something else"
+        span_text = "Nobelman </em> at 332, 113 S.Ct. 2106 (2010)"
+        start, end = re.search(re.escape(span_text), string).span()
+        _, _, balanced = maybe_balance_style_tags(start, end, string)
+        self.assertTrue(balanced.startswith("<em>"))
 
     def test_long_diff(self):
         """Does diffing work across a long text with many changes?"""


### PR DESCRIPTION
Solves #229. Adds tests
Also, bump version to v2.6.11