### PR TITLE
Add fix for hyperscan tokenizer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,11 @@ Features:
 - None
 
 Changes:
-- None
+- Modifies section regex and puctuation regex
 
 Fixes:
-- None
+- Fixes github action
+- Fixed an issue in `extract_tokens()` where regex re-run could fail on certain Hyperscan matches.  
 
 
 ## Current

--- a/eyecite/clean.py
+++ b/eyecite/clean.py
@@ -78,7 +78,9 @@ def all_whitespace(text: str) -> str:
     Returns:
         Text with collapsed whitespace characters.
     """
-    WHITESPACE_REGEX = r"[ \t\n\r\f\v\u00A0\u2002\u2003\u2009\u200B\u202F\u205F]+"
+    WHITESPACE_REGEX = (
+        r"[ \t\n\r\f\v\u00A0\u2002\u2003\u2009\u200B\u202F\u205F]+"
+    )
     return re.sub(WHITESPACE_REGEX, " ", text)
 
 

--- a/eyecite/clean.py
+++ b/eyecite/clean.py
@@ -78,7 +78,8 @@ def all_whitespace(text: str) -> str:
     Returns:
         Text with collapsed whitespace characters.
     """
-    return re.sub(r"\s+", " ", text)
+    WHITESPACE_REGEX = r"[ \t\n\r\f\v\u00A0\u2002\u2003\u2009\u200B\u202F\u205F]+"
+    return re.sub(WHITESPACE_REGEX, " ", text)
 
 
 def underscores(text: str) -> str:

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -52,7 +52,7 @@ PAGE_NUMBER_REGEX = rf"(?:\d+|{ROMAN_NUMERAL_REGEX}|_+)"
 
 # Regex to match punctuation around volume numbers and stopwords.
 # This could potentially be more precise.
-PUNCTUATION_REGEX = r"[^\sa-zA-Z0-9]*"
+PUNCTUATION_REGEX = r"[^\sa-zA-Z0-9]{,3}"
 
 # Regex for IdToken
 ID_REGEX = space_boundaries_re(r"id\.,?|ibid\.")
@@ -79,7 +79,7 @@ STOP_WORD_REGEX = space_boundaries_re(
 )
 
 # Regex for SectionToken
-SECTION_REGEX = r"(\S*§\S*)"
+SECTION_REGEX = space_boundaries_re(r"([\w\.\,\-]*§[\w\.\,\-]*)")
 
 # Regex for ParagraphToken
 PARAGRAPH_REGEX = r"(\n)"

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -299,8 +299,9 @@ class Tokenizer:
         # returned end offset. Also return text between matches.
         citation_tokens = []
         all_tokens: Tokens = []
+        tokens = [t for t in self.extract_tokens(text) if t is not None]
         tokens = sorted(
-            self.extract_tokens(text), key=lambda m: (m.start, -m.end)
+            tokens, key=lambda m: (m.start, -m.end)
         )
         last_token = None
         offset = 0
@@ -466,6 +467,9 @@ class HyperscanTokenizer(Tokenizer):
                 start = byte_to_str_offset[start]
                 end = byte_to_str_offset[end]
                 m = extractor.compiled_regex.match(text[start:end])
+                if not m:
+                    # skip if re-run regex fails to detect match
+                    continue
                 yield extractor.get_token(m, offset=start)
 
     @property

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -299,9 +299,8 @@ class Tokenizer:
         # returned end offset. Also return text between matches.
         citation_tokens = []
         all_tokens: Tokens = []
-        tokens = [t for t in self.extract_tokens(text) if t is not None]
         tokens = sorted(
-            tokens, key=lambda m: (m.start, -m.end)
+            self.extract_tokens(text), key=lambda m: (m.start, -m.end)
         )
         last_token = None
         offset = 0

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -635,7 +635,7 @@ class FindTest(TestCase):
                               metadata={'defendant': 'Goldsmith Seeds',
                                         'plaintiff': 'Farms',
                                         'court': 'scotus'})],
-             {'clean':['all_whitespace']}),
+             {'clean': ['all_whitespace']}),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Citation extraction")

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -630,6 +630,12 @@ class FindTest(TestCase):
                               metadata={'plaintiff': 'Commonwealth', 'defendant': 'Muniz',
                                         'court': 'pa'})]),
             ('Foo v. Bar,  1 F.Supp. 1 (SC 1967)', [case_citation(volume='1', reporter='F.Supp.', year=1967, page='1', metadata={'plaintiff': 'Foo', 'defendant': 'Bar', 'court': 'sc'})]),
+            ('Shady Grove Farms \xa0v Goldsmith Seeds 1 U.S. 1 (1981)', [
+                case_citation(year=1981,
+                              metadata={'defendant': 'Goldsmith Seeds',
+                                        'plaintiff': 'Farms',
+                                        'court': 'scotus'})],
+             {'clean':['all_whitespace']}),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Citation extraction")


### PR DESCRIPTION
Added an `if not m: continue` check to `extract_tokens()` 
to prevent processing invalid matches that fail when 
re-running the regex on extracted text. 

Previously, Hyperscan detected matches based on byte 
offsets, but some of these did not align properly 
when converted to Unicode string offsets. This caused
 `.match(text[start:end])` to return `None`, 
 potentially leading to errors when calling 
 `get_token(m, offset=start)`. 

Now, we explicitly skip such cases to ensure 
only valid tokens are processed.


Also - put some rationale constraints on the section regex
 and punctuation regexes to avoid matching indefinitely on gibberish.  