### PR TITLE
fix(maybe_balance_style_tags): search further for missing tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,8 @@ Changes:
 Fixes:
 - Prefer the other full citation on overlap with nominative reporter 
   citations #237
-
+- Update `maybe_balance_style_tags` to account for party names and intro words
+  inside the style tag #231
 
 ## Current
 


### PR DESCRIPTION
Fixes #231

Allow searching beyond only whitespace for the missing style tag. This helps finding the missing tag when a party name or intro word ("see") are included in the style span. Added tests