### PR TITLE
Issue 242 - Fix court detection when parenthetical includes date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
 -
 
 Fixes:
--
+- Fixes court detection with court/date parenthetical contains the month and day, e.g., `(C.D. Cal. Feb. 9, 2015)` #242
 
 ## Current
 

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -127,6 +127,8 @@ def add_post_citation(citation: CaseCitation, words: Tokens) -> None:
         offset = len(m["parenthetical"]) - len(citation.metadata.parenthetical)
         citation.full_span_end = citation.full_span_end - offset
     citation.metadata.year = m["year"]
+    citation.metadata.month = m["month"]
+    citation.metadata.day = m["day"]
     if m["year"]:
         citation.year = get_year(m["year"])
     if m["court"]:

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -289,6 +289,8 @@ class ResourceCitation(CitationBase):
         """Define fields on self.metadata."""
 
         year: Optional[str] = None
+        month: Optional[str] = None
+        day: Optional[str] = None
 
     def add_metadata(self, document: "Document"):
         """Extract metadata from text before and after citation."""

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -162,10 +162,18 @@ PARENTHETICAL_REGEX = r"""
 
 MONTH_REGEX = r"""
     (?P<month>
-        Jan\.|January|Feb\.|February|Mar\.|March|
-        Apr\.|April|May|June|July|Aug\.|August|
-        Sept\.|September|Oct\.|October|
-        Nov\.|November|Dec\.|December
+        January|Jan\.|
+        February|Feb\.|
+        March|Mar\.|
+        April|Apr\.|
+        May|
+        June|Jun\.|
+        July|Jul\.|
+        August|Aug\.|
+        September|Sept?\.|
+        October|Oct\.|
+        November|Nov\.|
+        December|Dec\.
     )
 """
 

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -276,32 +276,43 @@ SUPRA_ANTECEDENT_REGEX = r"""
 # Post full citation regex:
 # Capture metadata after a full cite. For example given the citation "1 U.S. 1"
 # with the following text:
-#   1 U.S. 1, 4-5, 2 S. Ct. 2, 6-7 (4th Cir. 2012) (overruling foo)
+#   1 U.S. 1, 4-5, 2 S. Ct. 2, 6-7 (4th Cir. Jan. 1, 2012) (overruling foo)
 # we want to capture:
 #   pin_cite = 4-5
 #   extra = 2 S. Ct. 2, 6-7
 #   court = 4th Cir.
+#   month = Jan.
+#   day = 1
 #   year = 2012
 #   parenthetical = overruling foo
 POST_FULL_CITATION_REGEX = rf"""
-    (?:  # handle a full cite with a valid year paren:
-        # content before year paren:
+    (?: # handle a full cite with a valid court+date paren:
+        # content before court+date paren:
         (?:
             # pin cite with comma and extra:
             {PIN_CITE_REGEX}?
             ,?\ ?
             (?P<extra>[^(;]*)
         )
-        # content within year paren:
-        [\(\[](?:
-            # court and year:
-            (?P<court>[^)]+)\ {YEAR_REGEX}|
-            # just year:
-            {YEAR_REGEX}
-        )[\)\]]
+        # content within court+date paren:
+        [\(\[] # opening paren or bracket
+        (?:
+            (?:
+                (?P<court>.*?) # treat anything before date as court
+                (?= # lookahead to stop when we see a month or year
+                    \s+{MONTH_REGEX} |
+                    \s+{YEAR_REGEX}
+                )
+            )?
+            \ ?
+            (?P<month>{MONTH_REGEX})?\ ?   # optional month
+            (?P<day>\d{{1,2}})?\,?\ ?      # optional day and comma
+            (?P<year>{YEAR_REGEX})         # year is required
+        )
+        [\)\]] # closing paren or bracket
         # optional parenthetical comment:
         {PARENTHETICAL_REGEX}
-    |  # handle a pin cite with no valid year paren:
+    |  # handle a pin cite with no valid court+date paren:
         {PIN_CITE_REGEX}
     )
 """

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -162,8 +162,10 @@ PARENTHETICAL_REGEX = r"""
 
 MONTH_REGEX = r"""
     (?P<month>
-        Jan\.|Feb\.|Mar\.|Apr\.|May|June|
-        July|Aug\.|Sept\.|Oct\.|Nov\.|Dec\.
+        Jan\.|January|Feb\.|February|Mar\.|March|
+        Apr\.|April|May|June|July|Aug\.|August|
+        Sept\.|September|Oct\.|October|
+        Nov\.|November|Dec\.|December
     )
 """
 

--- a/tests/test_CourtsTest.py
+++ b/tests/test_CourtsTest.py
@@ -32,6 +32,10 @@ class RegexesTest(TestCase):
             "State Kennedy, 666 P.2d 1316, 1326 (Or. 1983)": "or",
             "State v. Michael J., 875 A.2d 510, 534-35 (Conn. 2005)": "conn",
             "Commonwealth v. Muniz, 164 A.3d 1189 (Pa. 2017)": "pa",
+            "Commonwealth v. Shaffer, 209 A.3d 957, 969 (Pa. Jan. 1, 2019)": "pa",
+            "Sixty-Eight Liquors, Inc. v. Colvin, 118 S.W.3d 171 (Ky. Aug. 2, 2003)": "ky",
+            "Wisniewski v. Johns-Manville Corp., 812 F.2d 81, 83 (3rd Cir. June 30, 1987).": "ca3",
+            "Wallace v. Cellco P'ship, No. CV 14-8052-DSF (AS), 2015 WL 13908106, at *7 (C.D. Cal. Feb. 9, 2015)": "cacd",
         }
         for key in samples:
             eyecite_result = get_citations(key)

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -725,7 +725,7 @@ class FindTest(TestCase):
                  reporter='U.S. Dist. LEXIS',
                  page='12335',
                  year=2000,
-                 metadata={'plaintiff': "Corp.", 'defendant': "Nature's Farm Prods., No. 99 Civ. 9404 (SHS)"})
+                 metadata={'plaintiff': "Corp.", 'defendant': "Nature's Farm Prods., No. 99 Civ. 9404 (SHS)", "month": "Aug.", "day": "25", "court": "nysd"})
               ],),
             # Long pin cite -- make sure no catastrophic backtracking in regex
             ('1 U.S. 1, 2277, 2278, 2279, 2280, 2281, 2282, 2283, 2284, 2286, 2287, 2288, 2289, 2290, 2291',

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -152,6 +152,12 @@ class FindTest(TestCase):
                             metadata={'plaintiff': 'Commonwealth',
                                       'defendant': 'Muniz',
                                       'court': 'pa'})]),
+            # Test with month/day in court parenthetical
+            ('Commonwealth v. Muniz, 164 A.3d 1189 (Pa. Feb. 9, 2017)',
+             [case_citation(page='1189', reporter='A.3d', volume='164', year=2017,
+                            metadata={'plaintiff': 'Commonwealth',
+                                      'defendant': 'Muniz',
+                                      'court': 'pa'})]),
             # Parallel cite with parenthetical
             ('Bob Lissner v. Test 1 U.S. 12, 347-348, 1 S. Ct. 2, 358 (4th Cir. 1982) (overruling foo)',
              [case_citation(page='12', year=1982,

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -157,6 +157,8 @@ class FindTest(TestCase):
              [case_citation(page='1189', reporter='A.3d', volume='164', year=2017,
                             metadata={'plaintiff': 'Commonwealth',
                                       'defendant': 'Muniz',
+                                      'month': 'Feb.',
+                                      'day': '9',
                                       'court': 'pa'})]),
             # Parallel cite with parenthetical
             ('Bob Lissner v. Test 1 U.S. 12, 347-348, 1 S. Ct. 2, 358 (4th Cir. 1982) (overruling foo)',


### PR DESCRIPTION
As described in #242, there is currently a problem in detecting the court in a full citation when the parenthetical includes the specific date on which the opinion was issued, e.g., `(C.D. Cal. Feb. 9, 2015)`.

The problem is that we currently treat everything *before* the year as a potential court string, so `C.D. Cal. Feb. 9` in the example above. This causes the court lookup in `helpers.get_court_by_paren()` to fail.

This PR fixes this by modifying the `POST_FULL_CITATION_REGEX` regex to include capturing groups for potential months and days. If these are present, we capture them so the `<court>` group remains pristine (i.e., only `C.D. Cal.`). If they are not present, the behavior should be the same as it currently is.