### PR TITLE
Hyperscan encoding bug

### DIFF
--- a/eyecite/clean.py
+++ b/eyecite/clean.py
@@ -79,7 +79,7 @@ def all_whitespace(text: str) -> str:
     Returns:
         Text with collapsed whitespace characters.
     """
-    return re.sub(r"\s+", " ", text)
+    return re.sub(r"[\u200b\s]+", " ", text)
 
 
 def underscores(text: str) -> str:

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -345,10 +345,12 @@ class Tokenizer:
         # descending. Remove overlaps by returning only matches
         # where the current start offset is greater than the previously
         # returned end offset. Also return text between matches.
+        # filter out empty tokens cause by corrupted/complex pdf data
         citation_tokens = []
         all_tokens: Tokens = []
         tokens = sorted(
-            self.extract_tokens(text), key=lambda m: (m.start, -m.end)
+            (t for t in self.extract_tokens(text) if t.data is not None),
+            key=lambda m: (m.start, -m.end),
         )
         last_token = None
         offset = 0
@@ -526,7 +528,8 @@ class HyperscanTokenizer(Tokenizer):
                 start = byte_to_str_offset[start]
                 end = byte_to_str_offset[end]
                 m = extractor.compiled_regex.match(text[start:end])
-                yield extractor.get_token(m, offset=start)
+                if m:
+                    yield extractor.get_token(m, offset=start)
 
     @property
     def hyperscan_db(self):

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -660,8 +660,7 @@ class FindTest(TestCase):
              ),
             # extract no page citations
             ("\n 576 U.S. ___, 13",
-             [case_citation(volume='576', reporter='U.S.', page=None, metadata={'pin_cite': '13',
-                                      "court": 'scotus'})],
+             [case_citation(volume='576', reporter='U.S.', page=None, metadata={'pin_cite': '13', "court": 'scotus'})],
              {"clean_steps": ["all_whitespace"]},
              ),
             # test handling zero width whitespace
@@ -671,10 +670,9 @@ class FindTest(TestCase):
              ),
             # Test unprintable characters # /recap-documents/429621284"
             ("Shady Grove Farms v Goldsmith Seeds 1 U.S. 1  \x08*\x07\x07\u038bþİ\u038b\u202cڋ\u202a-\x14V\u202c\u202c",
-             [case_citation(metadata={'defendant': 'Goldsmith Seeds',
-                                     "plaintiff": 'Shady Grove Farms'})],
-            {"clean_steps": ["all_whitespace"]},
-            ),
+             [case_citation(metadata={'defendant': 'Goldsmith Seeds', "plaintiff": 'Shady Grove Farms'})],
+             {"clean_steps": ["all_whitespace"]},
+             ),
             ('(See In re K.F. (2009) 1 U.S. 1, 4 [92 Cal.Rptr.3d 784]; Yield Dynamics, Inc. v. TEA Systems Corp. (2007) 154 Cal.App.4th 547, 558 [66 Cal.Rptr.3d 1].)”', [
                 case_citation(
                     year=2009,

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -658,6 +658,23 @@ class FindTest(TestCase):
                 case_citation(
                  year=2009, metadata={'defendant': 'K.F.', "year": "2009"})]
              ),
+            # extract no page citations
+            ("\n 576 U.S. ___, 13",
+             [case_citation(volume='576', reporter='U.S.', page=None, metadata={'pin_cite': '13',
+                                      "court": 'scotus'})],
+             {"clean_steps": ["all_whitespace"]},
+             ),
+            # test handling zero width whitespace
+            ("Shady Grove Farms \u200bv Goldsmith Seeds 1 U.S. 1",
+             [case_citation(metadata={'defendant': 'Goldsmith Seeds', "plaintiff": 'Shady Grove Farms'})],
+             {"clean_steps": ["all_whitespace"]},
+             ),
+            # Test unprintable characters # /recap-documents/429621284"
+            ("Shady Grove Farms v Goldsmith Seeds 1 U.S. 1  \x08*\x07\x07\u038bþİ\u038b\u202cڋ\u202a-\x14V\u202c\u202c",
+             [case_citation(metadata={'defendant': 'Goldsmith Seeds',
+                                     "plaintiff": 'Shady Grove Farms'})],
+            {"clean_steps": ["all_whitespace"]},
+            ),
             ('(See In re K.F. (2009) 1 U.S. 1, 4 [92 Cal.Rptr.3d 784]; Yield Dynamics, Inc. v. TEA Systems Corp. (2007) 154 Cal.App.4th 547, 558 [66 Cal.Rptr.3d 1].)”', [
                 case_citation(
                     year=2009,


### PR DESCRIPTION
Bad weird encodings and zero width whitespace
were causing issues with hyperscan
tokenzier

A few small tweaks

Remove zero width whitespace
remove tokens without data
only return matches in extractors