### PR TITLE
Placeholder Citation Bug

### DIFF
--- a/eyecite/find.py
+++ b/eyecite/find.py
@@ -22,6 +22,7 @@ from eyecite.models import (
     FullLawCitation,
     IdCitation,
     IdToken,
+    PlaceholderCitation,
     ReferenceCitation,
     ResourceCitation,
     SectionToken,
@@ -87,6 +88,8 @@ def get_citations(
             citation_token = cast(CitationToken, token)
             if citation_token.short:
                 citation = _extract_shortform_citation(document, i)
+            elif citation_token.placeholder:
+                citation = _extract_placeholder_citation(document, i)
             else:
                 citation = _extract_full_citation(document, i)
                 if (
@@ -257,6 +260,28 @@ def _extract_full_citation(
     )
     citation.add_metadata(document)
 
+    return citation
+
+
+def _extract_placeholder_citation(
+    document: Document, index: int
+) -> PlaceholderCitation:
+    """Extract placeholder citation around token
+
+    Args:
+        document (): Document to parse
+        index (): the index of the placeholder token
+
+    Returns:placeholder citation
+    """
+    token = cast(CitationToken, document.words[index])
+    citation = PlaceholderCitation(token, index)
+    if document.markup_text:
+        find_case_name_in_html(citation, document)
+        if citation.metadata.defendant is None:
+            find_case_name(citation, document)
+    else:
+        find_case_name(citation, document)
     return citation
 
 

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -813,9 +813,7 @@ class PlaceholderCitationToken(Token):
     """Placeholder Citation Tokens."""
 
     @classmethod
-    def from_match(
-        cls, m, extra, offset=0
-    ) -> "Token":
+    def from_match(cls, m, extra, offset=0) -> "Token":
         """Handle placeholder citation token matches separately"""
 
         start, end = m.span()

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -813,13 +813,13 @@ class PlaceholderCitationToken(Token):
     """Placeholder Citation Tokens."""
 
     @classmethod
-    def from_match(cls, m, extra, offset=0) -> Optional["PlaceholderCitationToken"]:
+    def from_match(
+        cls, m, extra, offset=0
+    ) -> "Token":
         """Handle placeholder citation token matches separately"""
 
         start, end = m.span()
-        return cls(
-            m[0], start + offset, end + offset, **extra
-        )
+        return cls(m[0], start + offset, end + offset, **extra)
 
 
 @dataclass(eq=True, unsafe_hash=True)

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -812,6 +812,15 @@ class StopWordToken(Token):
 class PlaceholderCitationToken(Token):
     """Placeholder Citation Tokens."""
 
+    @classmethod
+    def from_match(cls, m, extra, offset=0) -> Optional["PlaceholderCitationToken"]:
+        """Handle placeholder citation token matches separately"""
+
+        start, end = m.span()
+        return cls(
+            m[0], start + offset, end + offset, **extra
+        )
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class CaseReferenceToken(Token):

--- a/eyecite/resolve.py
+++ b/eyecite/resolve.py
@@ -7,6 +7,7 @@ from eyecite.models import (
     FullCaseCitation,
     FullCitation,
     IdCitation,
+    PlaceholderCitation,
     ReferenceCitation,
     Resource,
     ResourceType,
@@ -348,6 +349,10 @@ def resolve_citations(
             resolution = resolve_id_citation(
                 citation, last_resolution, resolutions
             )
+
+        # If the citation is placeholder ignore for resolution purposes
+        elif isinstance(citation, PlaceholderCitation):
+            resolution = None
 
         # If the citation is to an unknown document, ignore for now
         else:

--- a/eyecite/test_factories.py
+++ b/eyecite/test_factories.py
@@ -7,6 +7,8 @@ from eyecite.models import (
     FullLawCitation,
     IdCitation,
     IdToken,
+    PlaceholderCitation,
+    PlaceholderCitationToken,
     ReferenceCitation,
     SectionToken,
     ShortCaseCitation,
@@ -115,3 +117,14 @@ def unknown_citation(source_text=None, index=0, **kwargs):
 def supra_citation(source_text=None, index=0, **kwargs):
     """Convenience function for creating mock SupraCitation objects."""
     return SupraCitation(SupraToken(source_text, 0, 99), index, **kwargs)
+
+
+def placeholder_citation(source_text=None, index=0, **kwargs):
+    """Convenience function for creating mock Placeholder Citation objects."""
+    volume = kwargs.pop("volume", None)
+    reporter = kwargs.pop("reporter", None)
+    page = kwargs.pop("page", None)
+
+    group = {"volume": volume, "reporter": reporter, "page": page}
+    token = PlaceholderCitationToken(source_text, 0, 99, groups=group)
+    return PlaceholderCitation(token, index, **kwargs)

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -220,6 +220,12 @@ class FindTest(TestCase):
             # a comma (cf. eyecite#137)
             ('1 U. S. ___,',
              [case_citation(volume='1', reporter_found='U. S.', page=None)]),
+            # can we handle placeholder citations in all tokenizers
+            ('She Enterprises, Inc. v. License Commission of Worcester, ___ U.S. ___, ___, 412 N.E.2d 883 (1980).',
+             [case_citation(volume='412', reporter='N.E.2d', page="883",
+                            metadata={'plaintiff': 'She Enterprises, Inc.',
+                                      'defendant': 'License Commission of Worcester',
+                                      'year': '1980'})]),
             # Test with the 'digit-REPORTER-digit' corner-case formatting
             ('2007-NMCERT-008',
              [case_citation(source_text='2007-NMCERT-008', page='008',

--- a/tests/test_ResolveTest.py
+++ b/tests/test_ResolveTest.py
@@ -177,8 +177,8 @@ class ResolveTest(TestCase):
         # Test resolving two full citations with missing page numbers but
         # otherwise identical. These should not resolve to the same document.
         self.checkResolution(
-            (0, "Foo v. Bar, 1 U.S. ____."),
-            (1, "Foo v. Bar, 1 U.S. ____."),
+            (None, "Foo v. Bar, 1 U.S. ____."),
+            (None, "Foo v. Bar, 1 U.S. ____."),
         )
         # Test resolving multiple full citations to different documents
         self.checkResolution(
@@ -310,7 +310,7 @@ class ResolveTest(TestCase):
         # Test resolving an Id. citation with a pin cite when the previous
         # citation only has a placeholder page. We expect this to fail.
         self.checkResolution(
-            (0, "Foo v. Bar, 1 U.S. ___"),
+            (None, "Foo v. Bar, 1 U.S. ___"),
             (None, "Id. at 100."),
         )
 


### PR DESCRIPTION
Previously, eyecite was detecting placeholder citations in two ways—via our catch-all _+ page regex (which treated any placeholder with a volume as a full case citation) and via the dedicated placeholder tokenizer (which caught those without volumes). Under Hyperscan this overlap led to inconsistent citation types.

To address this:
	•	Removed the blanket _+ from the page regex
	•	Consolidated all placeholder extraction and added a placeholder flag during the tokenization
	•	Updated resolution logic to exclude placeholders (they can’t be resolved)
	•	Added tests to and test factories to handle them.