### PR TITLE
Placeholder Citation Regex overlap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Features:
 -
 
 Changes:
--
+- Small tweak to placeholder citations regexes and added a few more known reps
 
 Fixes:
 -

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -93,7 +93,7 @@ common_placeholder_reporters = [
     r"A\.?2d",
     r"A\.?3d",
     r"AD3d",
-    r"Cal.",
+    r"Cal\.",
     r"F\.?3d",
     r"F\.Supp\.2d",
     r"Idaho",
@@ -107,6 +107,7 @@ common_placeholder_reporters = [
     r"N\.W\.2d",
     r"N\.W\.3d",
     r"N\.?Y\.?",
+    r"Nev\.",
     r"NY3d",
     r"Ohio\sSt\.3d",
     r"P\.?3d",
@@ -125,7 +126,7 @@ common_placeholder_reporters = [
 placeholder_reporters = "|".join(common_placeholder_reporters)
 
 # Regex for Placeholder Citations
-PLACEHOLDER_CITATIONS = rf"((— Nev. —)|(___ ({placeholder_reporters}) ___))"
+PLACEHOLDER_CITATIONS = rf"([_—–-]+\s({placeholder_reporters})\s[_—–-]+)"
 
 
 # *** Metadata regexes: ***

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -89,8 +89,43 @@ SECTION_REGEX = r"(\S*§\S*)"
 # Regex for ParagraphToken
 PARAGRAPH_REGEX = r"(\n)"
 
+common_placeholder_reporters = [
+    r"A\.?2d",
+    r"A\.?3d",
+    r"AD3d",
+    r"Cal.",
+    r"F\.?3d",
+    r"F\.Supp\.2d",
+    r"Idaho",
+    r"Iowa",
+    r"L\.Ed\.",
+    r"Mass\.",
+    r"N\.?J\.?",
+    r"N\.C\.\s?App\.",
+    r"N\.E\.3d",
+    r"N\.J\.\sSuper\.(\sat)?",
+    r"N\.W\.2d",
+    r"N\.W\.3d",
+    r"N\.?Y\.?",
+    r"NY3d",
+    r"Ohio\sSt\.3d",
+    r"P\.?3d",
+    r"S\.?E\.?2d",
+    r"S\.?E\.?3d",
+    r"S\.?W\.?2d",
+    r"S\.?W\.?3d",
+    r"S\.C\.",
+    r"S\.Ct\.",
+    r"So\.?3d",
+    r"U\.\s?S\.",
+    r"W\.Va\.",
+    r"Wis\.\s?2d",
+]
+
+placeholder_reporters = "|".join(common_placeholder_reporters)
+
 # Regex for Placeholder Citations
-PLACEHOLDER_CITATIONS = r"((— Nev. —)|(\d{1,3} U\.\s?S\. ___)|(___ U\.\s?S\. ___))"
+PLACEHOLDER_CITATIONS = rf"((— Nev. —)|(___ ({placeholder_reporters}) ___))"
 
 
 # *** Metadata regexes: ***

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -90,7 +90,7 @@ SECTION_REGEX = r"(\S*§\S*)"
 PARAGRAPH_REGEX = r"(\n)"
 
 # Regex for Placeholder Citations
-PLACEHOLDER_CITATIONS = r"(— Nev. —)|(\d{1,3} U\.\s?S\. ___)|(___ U.\s?S. ___)"
+PLACEHOLDER_CITATIONS = r"((— Nev. —)|(\d{1,3} U\.\s?S\. ___)|(___ U\.\s?S\. ___))"
 
 
 # *** Metadata regexes: ***

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -474,10 +474,80 @@ class FindTest(TestCase):
                                       'defendant': 'State of Washington',
                                       'year': '1962'})]
              ),
+            # As seen in /107252/miranda-v-arizona/
             ('(Mo.); Bean v. State, — Nev. —, 398 P. 2d 251; ',
              [case_citation(volume='398', reporter='P. 2d', page='251',
                             metadata={'plaintiff': 'Bean',
                                       'defendant': 'State'})]
+             ),
+            # https://www.courtlistener.com/opinion/4439963/mark-a-twilegar/
+            # Common em-dash format
+            ('Hurst v. Florida, — U.S. —, 136 S.Ct. 616, 193 L.Ed.2d 504 (2016)',
+             [case_citation(volume='136', reporter='S.Ct.', page='616',
+                            metadata={'plaintiff': 'Hurst',
+                                      'defendant': 'Florida',
+                                      'year': '2016',
+                                      'court': 'scotus',
+                                      'extra': '193 L.Ed.2d 504'
+                                      }),
+              case_citation(volume='193', reporter='L.Ed.2d', page='504',
+                            metadata={'plaintiff': 'Hurst',
+                                      'defendant': 'Florida',
+                                      'year': '2016',
+                                      })
+              ]
+             ),
+            # https://www.courtlistener.com/opinion/9502461/balderas
+            # Single underscore placeholder
+            ('In Viking River Cruises v. Moriana (2022) _ U.S. _ [213 L.Ed.2d 179, 200-201] (Viking River)',
+             [case_citation(volume='213', reporter='L.Ed.2d', page='179',
+                            metadata={'plaintiff': 'Viking River Cruises',
+                                      'defendant': 'Moriana',
+                                      'year': '2022',
+                                      'pin_cite': '200-201',
+                                      })
+              ]
+             ),
+            # Two underscore placeholder
+            # https://www.courtlistener.com/opinion/5290606/williams
+            ('decision in Epic Systems Corporation v. Lewis (2018) __ U.S. __ [138 S.Ct. 1612] (Epic Systems)',
+             [case_citation(volume='138', reporter='S.Ct.', page='1612',
+                            metadata={'plaintiff': 'Epic Systems Corporation',
+                                      'defendant': 'Lewis',
+                                      'year': '2018',
+                                      'court': 'scotus',
+                                      })
+              ]
+             ),
+            # https://www.courtlistener.com/opinion/9780755/touchard
+            # test complicated multiple citations with placeholders
+            ('speech.” Houston Cmty. Coll. Sys. v. Wilson, ---- U.S. ----, '
+             '142 S. Ct. 1253, 1259, ---- L. Ed. 2d ---- (2022) (emphasis added) '
+             '(quoting Nieves v. Bartlett, ---- U.S. ----, 139 S. Ct. 1715, '
+             '1722, 204 L. Ed. 2d 1 (2019);',
+             [case_citation(volume='142', reporter='S. Ct.', page='1253',
+                            metadata={'plaintiff': 'Sys.',
+                                      'defendant': 'Wilson',
+                                      'year': '2022',
+                                      'pin_cite': '1259',
+                                      'court': 'scotus',
+                                      'extra': '---- L. Ed. 2d ----',
+                                      'parenthetical': 'emphasis added',
+                                      }),
+              case_citation(volume='139', reporter='S. Ct.', page='1715',
+                            metadata={'plaintiff': 'Nieves',
+                                      'defendant': 'Bartlett',
+                                      'year': '2019',
+                                      'extra': '204 L. Ed. 2d 1',
+                                      'court': 'scotus',
+                                      'pin_cite': '1722',
+                                      }),
+              case_citation(volume='204', reporter='L. Ed. 2d', page='1',
+                            metadata={'plaintiff': 'Nieves',
+                                      'defendant': 'Bartlett',
+                                      'year': '2019',
+                                      })
+              ]
              ),
             # test lower case sentence
             ('curiams. Spano v. People of State of New York, 360 U.S. 315',
@@ -485,7 +555,6 @@ class FindTest(TestCase):
                             metadata={'plaintiff': 'Spano',
                                       'defendant': 'People of State of New York'})]
              ),
-
             # Test capitalized word
             ('Per Curiams. Spano v. People of State of New York, 360 U.S. 315',
              [case_citation(volume='360', reporter='U.S.', page='315',
@@ -1369,6 +1438,21 @@ class FindTest(TestCase):
                     )
                 ],
                 {"clean_steps": ["html", "inline_whitespace"]},
+            ),
+            (
+                "Craig v. Harrah, ___ Nev. ___ [201 P.2d 1081]. (",
+                [
+                    case_citation(
+                        page="1081",
+                        volume="201",
+                        reporter="P.2d",
+                        short=False,
+                        metadata={
+                            "plaintiff": "Craig",
+                            "defendant": "Harrah",
+                        },
+                    )
+                ],
             ),
             # tricky scotus fake cites if junk is inbetween remove it
             (


### PR DESCRIPTION
Placeholder regexes overlapped in some instances with full case citations.  This PR removes the overlap by 
requiring placeholder citations to follow this ___ XXX ___ or - Nev. - format.  

Also, updated the placeholder to allow more known common placeholder reporter patterns.  

This should resolve this sentry issue.  

https://freelawproject.sentry.io/issues/6573913691/?project=5257254&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=1
