### PR TITLE
fix(helpers): A citation in a parenthetical should not emit the warning "Unknown overlap case"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Changes:
 Fixes:
 - Add fix for reference citation filtering out bad matches
 - Fix for hyperscan bug and whitespace bug
+- A citation in a parenthetical should not emit the warning "Unknown overlap case"
 
 ## Current
 
@@ -261,7 +262,7 @@ Changes:
      - The `reporter` attribute has been removed from citations and replaced with the `corrected_reporter()` method.
      - Similarly, the `base_citation()` method has been renamed as `corrected_citation()`, and the `formatted()` method has been renamed as `corrected_citation_full()`.
      - The `do_defendant` and `do_post_citation` arguments to `get_citations` have been removed. They're fast enough to just always do. No need to think about these further.\
-     - The `resolve_fullcase_citation` parameter in the `resolve_citations` function has been renamed to `resolve_full_citation`.  
+     - The `resolve_fullcase_citation` parameter in the `resolve_citations` function has been renamed to `resolve_full_citation`.
 
 Fixes:
  - Support for reporter citations with `volume=None` is added. Some reporters don't use volumes, for example, "Bankr. L. Rep. (CCH) P12,345".

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -1098,7 +1098,8 @@ def filter_citations(citations: list[CitationBase]) -> list[CitationBase]:
                 continue
 
             # A citation in a parenthetical would also overlap and should be kept.
-            if citation.matched_text() in last_citation.metadata.parenthetical:
+            paren = last_citation.metadata.parenthetical
+            if paren and citation.matched_text() in paren:
                 filtered_citations.append(citation)
                 continue
 

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -1097,6 +1097,11 @@ def filter_citations(citations: list[CitationBase]) -> list[CitationBase]:
             ):
                 continue
 
+            # A citation in a parenthetical would also overlap and should be kept.
+            if citation.matched_text() in last_citation.metadata.parenthetical:
+                filtered_citations.append(citation)
+                continue
+
             # Known overlap case are parallel full citations
             if not (
                 isinstance(citation, FullCaseCitation)

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -1902,7 +1902,7 @@ class FindTest(TestCase):
         )
         self.run_test_pairs(test_pairs, "Citation extraction")
 
-    @patch('eyecite.helpers.logger.warning')
+    @patch("eyecite.helpers.logger.warning")
     def test_citation_in_parenthetical_does_not_emit_warning(self, mock_warn):
         """
         These two citations are overlapping, but they are not parallel citations. No

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -2,6 +2,7 @@ import os
 from copy import copy
 from datetime import datetime
 from unittest import TestCase
+from unittest.mock import patch
 
 from eyecite import get_citations
 from eyecite.find import extract_reference_citations
@@ -1900,3 +1901,14 @@ class FindTest(TestCase):
             ),
         )
         self.run_test_pairs(test_pairs, "Citation extraction")
+
+    @patch('eyecite.helpers.logger.warning')
+    def test_citation_in_parenthetical_does_not_emit_warning(self, mock_warn):
+        """
+        These two citations are overlapping, but they are not parallel citations. No
+        warning should be emitted.
+        """
+        text = "Gotthelf v. Toyota Motor Sales, U.S.A., Inc., 525 F. App’x 94, 103 n.15 (3d Cir. 2013) (quoting Iqbal, 556 U.S. at 686-87)."
+        citations = get_citations(text)
+        self.assertEqual(len(citations), 2)
+        mock_warn.assert_not_called()


### PR DESCRIPTION
Previously, a citation like "X v. Y 525 F. App’x 94, 103 n.15 (3d Cir. 2013) (quoting Iqbal, 556 U.S. at 686-87)" would lead to a warning "Unknown overlap case."

However this warning was written with the expectation that overlapping cases would be parallel citations, and that all parallel citations should be FullCaseCitations.

This PR updates the code to handle the case when there is a citation in a parenthetical, in which case the two cases would be overlapping, but do not have to both be FullCaseCitations.