### PR TITLE
fix(reference_filter): Loosen restriction on references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
 
 Fixes:
 - Fixes court detection with court/date parenthetical contains the month and day, e.g., `(C.D. Cal. Feb. 9, 2015)` #242
+- Fixes over reference filtering in markup text
 
 ## Current
 

--- a/eyecite/find.py
+++ b/eyecite/find.py
@@ -454,7 +454,7 @@ def find_reference_citations_from_markup(
                 start_in_markup + match.end(1), bisect_right
             )
             raw_after = document.plain_text[full_end_in_plain:]
-            if re.match(r"^\s*(at|v[.s]|supra)\s", raw_after):
+            if re.match(r"^\s*(v[.s]|supra)\s", raw_after):
                 # filter likely bad reference matches
                 # when matching reference citations in markup it is possible
                 # to have a pattern like this `<i>Foo</i> v. <i>Bar, supra</i>`

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -1105,7 +1105,7 @@ def filter_citations(citations: list[CitationBase]) -> list[CitationBase]:
             ):
                 continue
 
-            # A citation in a parenthetical would also overlap and should be kept.
+            # A citation in a paren would also overlap and should be kept.
             paren = last_citation.metadata.parenthetical
             if paren and citation.matched_text() in paren:
                 filtered_citations.append(citation)

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -814,7 +814,17 @@ class FindTest(TestCase):
             ("Angelopoulos v. Keystone Orthopedic Specialists, S.C., Wachn, LCC, 2015 WL 2375225",
              [case_citation(volume="2015", reporter="WL", page="2375225",
                             metadata={"plaintiff": "Angelopoulos", "defendant": "Keystone Orthopedic Specialists, S.C., Wachn, LCC"})]
-             )
+             ),
+            ("See <em>Bivens </em>v. <em>Six Unknown Fed. Narcotics Agents, </em>403 U. S. 388 (1971). "
+             "The legal issue there was whether a <em>Bivens </em> at 122, action can be employed...",
+             [case_citation(volume="403", reporter="U. S.", page="388",
+                            metadata={"plaintiff": "Bivens",
+                                      "defendant": "Six Unknown Fed. Narcotics Agents",
+                                      "court": "scotus",
+                                      "year": "1971"},
+                            ),
+              reference_citation("Bivens", metadata={"plaintiff": "Bivens", "pin_cite": "at 122"})],
+             {'clean_steps': ['html', 'inline_whitespace']}),
         )
 
         # fmt: on


### PR DESCRIPTION
Remove `at` as a disallowed word following a reference filter in markup.

Add a test and fix a lint comment length warning.

