### PR TITLE
fix(tokenizer): Correct parsing of line number + short cite

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
 -
 
 Fixes:
--
+- Fix parsing of short cites that occur after a line number #267, #264
 
 ## Current
 

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -388,7 +388,7 @@ class Tokenizer:
         # where the current start offset is greater than the previously
         # returned end offset. Also return text between matches.
         # filter out empty tokens cause by corrupted/complex pdf data
-        citation_tokens = []
+        citation_tokens: list[tuple[int, Token]] = []
         all_tokens: Tokens = []
         tokens = sorted(
             (t for t in self.extract_tokens(text) if t.data is not None),

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -337,7 +337,9 @@ class Tokenizer:
         """Tokenize text and return list of all tokens, followed by list of
         just non-string tokens along with their positions in the first list."""
 
-        def _is_short_cite_following_line_number(last_token: Token | None, token: Token) -> bool:
+        def _is_short_cite_following_line_number(
+            last_token: Token | None, token: Token
+        ) -> bool:
             """
             When we have a short cite following a line number, it can result in two
             CitationTokens.
@@ -357,7 +359,9 @@ class Tokenizer:
             """
             if last_token is None:
                 return False
-            if not isinstance(last_token, CitationToken) or not isinstance(token, CitationToken):
+            if not isinstance(last_token, CitationToken) or not isinstance(
+                token, CitationToken
+            ):
                 return False
             last_token_volume = last_token.groups.get("volume")
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -1128,17 +1128,22 @@ class FindTest(TestCase):
         cite starting on a line, in a PDF that includes line numbers, we parse the short
         cite correctly.
         """
+        no_ed = {"exact_editions": (), "edition_guess": None}
         pairs = [
             # Correctly parsed cases
             (
                 # From https://www.courtlistener.com/api/rest/v3/recap-documents/139032416/
                 "21 Taylor, 281 F.3d at 830",
-                case_citation(volume="281", reporter="F.3d", page="830", short=True),
+                case_citation(
+                    volume="281", reporter="F.3d", page="830", short=True
+                ),
             ),
             (
                 # From https://www.courtlistener.com/api/rest/v3/recap-documents/139032384/
                 "28 Phillips, 415 F.3d at 1321",
-                case_citation(volume="415", reporter="F.3d", page="1321", short=True),
+                case_citation(
+                    volume="415", reporter="F.3d", page="1321", short=True
+                ),
             ),
             # Making sure we aren't overzealous -- we should take the first citation in
             # these cases.
@@ -1148,24 +1153,39 @@ class FindTest(TestCase):
             # edition is attached, the correct_reporter() becomes "Tay." and then the
             # two objects don't match.
             (
+                # Volume number too large
                 "212 Taylor, 281 F.3d at 830",
-                case_citation(volume="212", reporter="Taylor", page="281", exact_editions=(), edition_guess=None),
+                case_citation(
+                    volume="212", reporter="Taylor", page="281", **no_ed
+                ),
             ),
             (
+                # Volume number too large
                 "212 Taylor, 281 Thompson 830",
-                case_citation(volume="212", reporter="Taylor", page="281", exact_editions=(), edition_guess=None),
+                case_citation(
+                    volume="212", reporter="Taylor", page="281", **no_ed
+                ),
             ),
             (
+                # No comma after reporter
                 "212 Taylor 281 Thompson 830",
-                case_citation(volume="212", reporter="Taylor", page="281", exact_editions=(), edition_guess=None),
+                case_citation(
+                    volume="212", reporter="Taylor", page="281", **no_ed
+                ),
             ),
             (
+                # No comma after reporter
                 "21 Taylor 281 F.3d at 830",
-                case_citation(volume="21", reporter="Taylor", page="281", exact_editions=(), edition_guess=None),
+                case_citation(
+                    volume="21", reporter="Taylor", page="281", **no_ed
+                ),
             ),
             (
+                # The two citations don't actually overlap
                 "21 Taylor, 281 and 281 F.3d at 830",
-                case_citation(volume="21", reporter="Taylor", page="281", exact_editions=(), edition_guess=None),
+                case_citation(
+                    volume="21", reporter="Taylor", page="281", **no_ed
+                ),
             ),
         ]
         for cite_string, cite_object in pairs:


### PR DESCRIPTION
Fixes https://github.com/freelawproject/eyecite/issues/264

Would appreciate feedback on:
1) naming
2) placement of the helper nested function inside `tokenize`.

Let me know what you think!