### PR TITLE
feat(annotate): Use placeholder markup for annotating

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Features:
 -
 
 Changes:
--
+- Add method to remove tags from markup to avoid diffing bug
 
 Fixes:
 -

--- a/eyecite/annotate.py
+++ b/eyecite/annotate.py
@@ -10,7 +10,8 @@ import fast_diff_match_patch
 from eyecite.utils import (
     is_balanced_html,
     maybe_balance_style_tags,
-    wrap_html_tags, placeholder_markup,
+    placeholder_markup,
+    wrap_html_tags,
 )
 
 logger = getLogger(__name__)
@@ -182,7 +183,9 @@ def annotate_citations(
         plain_text = source_text
     elif source_text and source_text != plain_text:
         placeholder_text = placeholder_markup(source_text)
-        offset_updater = SpanUpdater(plain_text, placeholder_text, use_dmp=use_dmp)
+        offset_updater = SpanUpdater(
+            plain_text, placeholder_text, use_dmp=use_dmp
+        )
         plain_text = source_text
 
     # append text for each annotation to out

--- a/eyecite/annotate.py
+++ b/eyecite/annotate.py
@@ -10,7 +10,7 @@ import fast_diff_match_patch
 from eyecite.utils import (
     is_balanced_html,
     maybe_balance_style_tags,
-    wrap_html_tags,
+    wrap_html_tags, placeholder_markup,
 )
 
 logger = getLogger(__name__)
@@ -181,7 +181,8 @@ def annotate_citations(
     if offset_updater:
         plain_text = source_text
     elif source_text and source_text != plain_text:
-        offset_updater = SpanUpdater(plain_text, source_text, use_dmp=use_dmp)
+        placeholder_text = placeholder_markup(source_text)
+        offset_updater = SpanUpdater(plain_text, placeholder_text, use_dmp=use_dmp)
         plain_text = source_text
 
     # append text for each annotation to out

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -917,6 +917,10 @@ class Document:
                 )
 
             self.plain_text = clean_text(self.markup_text, self.clean_steps)
+
+            # Replace original tags (including their attributes) with same‐length placeholders
+            # so that SpanUpdater’s offset calculations remain correct and aren’t skewed by
+            # attribute characters (e.g., in id or index). ex. <span> <XXXX>
             placeholder_markup = placeholder_markup(self.markup_text)
 
             self.plain_to_markup = SpanUpdater(
@@ -955,29 +959,3 @@ class Document:
         """Tokenize the document and store the results in the document
         object"""
         self.words, self.citation_tokens = tokenizer.tokenize(self.plain_text)
-
-    #
-    # def placeholder_markup(self, html: str) -> str:
-    #     """Create placeholder HTML to identify annotation locations.
-    #
-    #     This allows diffing or annotation algorithms to maintain correct
-    #     character offsets by hiding tags behind 'X's of the same length.
-    #
-    #     Args:
-    #         html: The raw HTML string to sanitize.
-    #
-    #     Returns:
-    #         A safe string to annotate
-    #     """
-    #     tag_re = re.compile(r"<([\/a-z])[^>]+>")
-    #
-    #     def _replace(m: re.Match) -> str:
-    #         """Replace tags with placeholder tags"""
-    #         tag = m.group(0)
-    #         if tag.startswith("</"):
-    #             return "</" + "X" * (len(tag) - 3) + ">"
-    #         else:
-    #             return "<" + "X" * (len(tag) - 2) + ">"
-    #
-    #     text = tag_re.sub(_replace, html)
-    #     return text

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -900,6 +900,7 @@ class Document:
     source_text: str = ""  # will be useful for the annotation step
 
     def __post_init__(self):
+        from eyecite.utils import placeholder_markup
         if self.plain_text and not self.markup_text:
             self.source_text = self.plain_text
             if self.clean_steps:
@@ -915,9 +916,10 @@ class Document:
                 )
 
             self.plain_text = clean_text(self.markup_text, self.clean_steps)
+            placeholder_markup = placeholder_markup(self.markup_text)
 
             self.plain_to_markup = SpanUpdater(
-                self.plain_text, self.markup_text
+                self.plain_text, placeholder_markup
             )
             self.markup_to_plain = SpanUpdater(
                 self.markup_text, self.plain_text
@@ -952,3 +954,28 @@ class Document:
         """Tokenize the document and store the results in the document
         object"""
         self.words, self.citation_tokens = tokenizer.tokenize(self.plain_text)
+    #
+    # def placeholder_markup(self, html: str) -> str:
+    #     """Create placeholder HTML to identify annotation locations.
+    #
+    #     This allows diffing or annotation algorithms to maintain correct
+    #     character offsets by hiding tags behind 'X's of the same length.
+    #
+    #     Args:
+    #         html: The raw HTML string to sanitize.
+    #
+    #     Returns:
+    #         A safe string to annotate
+    #     """
+    #     tag_re = re.compile(r"<([\/a-z])[^>]+>")
+    #
+    #     def _replace(m: re.Match) -> str:
+    #         """Replace tags with placeholder tags"""
+    #         tag = m.group(0)
+    #         if tag.startswith("</"):
+    #             return "</" + "X" * (len(tag) - 3) + ">"
+    #         else:
+    #             return "<" + "X" * (len(tag) - 2) + ">"
+    #
+    #     text = tag_re.sub(_replace, html)
+    #     return text

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -901,6 +901,7 @@ class Document:
 
     def __post_init__(self):
         from eyecite.utils import placeholder_markup
+
         if self.plain_text and not self.markup_text:
             self.source_text = self.plain_text
             if self.clean_steps:
@@ -954,6 +955,7 @@ class Document:
         """Tokenize the document and store the results in the document
         object"""
         self.words, self.citation_tokens = tokenizer.tokenize(self.plain_text)
+
     #
     # def placeholder_markup(self, html: str) -> str:
     #     """Create placeholder HTML to identify annotation locations.

--- a/eyecite/utils.py
+++ b/eyecite/utils.py
@@ -315,3 +315,29 @@ def maybe_balance_style_tags(
                 start = extended_start + matches[-1].start()
 
     return start, end, plain_text[start:end]
+
+
+def placeholder_markup(html: str) -> str:
+    """Create placeholder HTML to identify annotation locations.
+
+    This allows diffing or annotation algorithms to maintain correct
+    character offsets by hiding tags behind 'X's of the same length.
+
+    Args:
+        html: The raw HTML string to sanitize.
+
+    Returns:
+        A safe string to annotate
+    """
+    tag_re = re.compile(r"<([\/a-z])[^>]+>")
+
+    def _replace(m: re.Match) -> str:
+        """Replace tags with placeholder tags"""
+        tag = m.group(0)
+        if tag.startswith("</"):
+            return "</" + "X" * (len(tag) - 3) + ">"
+        else:
+            return "<" + "X" * (len(tag) - 2) + ">"
+
+    text = tag_re.sub(_replace, html)
+    return text

--- a/tests/test_AnnotateTest.py
+++ b/tests/test_AnnotateTest.py
@@ -200,6 +200,27 @@ class AnnotateTest(TestCase):
                     "use_markup": True,
                 },
             ),
+            (
+                """<p index="143">2016 WL 4217254</p>.<p index="144">id.</p>""",
+                """<p index="143"><0>2016 WL 4217254</0></p>.<p index="144"><1>id.</1></p>""",
+                ["html", "all_whitespace"],
+                {
+                    "annotate_anchors": False,
+                    "unbalanced_tags": "skip",
+                    "use_markup": True,
+                },
+            ),
+            # Ensure < does not affect annotations
+            (
+                """contending it <12123 is < the most “apt.” “ ‘[A] vast enterprise usu. <p index="143">2016 WL 4217254</p>""",
+                """contending it <12123 is < the most “apt.” “ ‘[A] vast enterprise usu. <p index="143"><0>2016 WL 4217254</0></p>""",
+                ["html", "all_whitespace"],
+                {
+                    "annotate_anchors": False,
+                    "unbalanced_tags": "skip",
+                    "use_markup": True,
+                },
+            ),
         )
         for source_text, expected, clean_steps, *annotate_kwargs in test_pairs:
             annotate_kwargs = annotate_kwargs[0] if annotate_kwargs else {}


### PR DESCRIPTION
@grossir 

We can use the placeholder markup from the start and avoid other unnecessary changes and 
downstream affects like changing CL or reinstantiating the offset updater.  