### PR TITLE
docs: Simplify hyperscan installation instructions

### DIFF
--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -20,9 +20,6 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
-      - name: Install hyperscan
-        run: sudo apt-get install libhyperscan-dev
-
       - name: Get full Python version
         id: full-python-version
         run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,6 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
-      - name: Install hyperscan
-        run: sudo apt-get install libhyperscan-dev
-
       - name: Get full Python version
         id: full-python-version
         run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT

--- a/README.rst
+++ b/README.rst
@@ -381,8 +381,12 @@ HyperscanTokenizer
 The alternate HyperscanTokenizer compiles all extraction regexes into a hyperscan database
 so they can be extracted in a single pass. This is far faster than the default tokenizer
 (exactly how much faster depends on how many citation formats are included in the target text),
-but requires the optional :code:`hyperscan` dependency that has limited platform support.
-See the "Installation" section for hyperscan installation instructions and limitations.
+but requires the optional dependency `hyperscan <https://pypi.org/project/hyperscan/>`__,
+which you can install with Pip like:
+
+::
+
+    pip install hyperscan
 
 Compiling the hyperscan database takes several seconds, so short-running scripts may want to
 provide a cache directory where the database can be stored. The directory should be writeable
@@ -391,7 +395,6 @@ only by the user:
 ::
 
     hyperscan_tokenizer = HyperscanTokenizer(cache_dir='.hyperscan')
-
 
 Debugging
 ---------
@@ -452,36 +455,6 @@ Or via pip::
 Or install the latest dev version from github::
 
     pip install https://github.com/freelawproject/eyecite/archive/main.zip#egg=eyecite
-
-Hyperscan installation
-----------------------
-
-To use :code:`HyperscanTokenizer` you must additionally install the python `hyperscan <https://pypi.org/project/hyperscan/>`_
-library and its dependencies. **python-hyperscan officially supports only x86 linux,** though other configurations may be
-possible.
-
-Hyperscan installation example on x86 Ubuntu 20.04:
-
-::
-
-    apt install libhyperscan-dev
-    pip install hyperscan
-
-Hyperscan installation example on x86 Debian Buster:
-
-::
-
-    echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
-    apt install -t buster-backports libhyperscan-dev
-    pip install hyperscan
-
-Hyperscan installation example with homebrew on x86 MacOS:
-
-::
-
-    brew install hyperscan
-    pip install hyperscan
-
 
 Deployment
 ==========


### PR DESCRIPTION
Back when the hyperscan installation docs were written in bb741e0daa5d913ae01571f8aecbee188cf087c7 (2021), hyperscan was a bit difficult to install because it required libhyperscan on the system. But since hyperscan version 0.3.0 (2022), it has statically linked libhyperscan, so it’s not much different from other PyPI packages. This commit simplifies the documentation and drops our CI installation of libhyperscan-dev.