### PR TITLE
chore: Remove libhyperscan install from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,9 +25,6 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
-      - name: Install hyperscan
-        run: sudo apt-get install libhyperscan-dev
-
       - name: Get full Python version
         id: full-python-version
         run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Missed in #275.