### PR TITLE
Refactor Document model to simplify public-facing API

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from matplotlib import pyplot as plt  # type: ignore
 
-from eyecite import get_citations
+from eyecite import Document, get_citations
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
@@ -59,11 +59,13 @@ class Benchmark:
             if text:
                 # Remove XML encodings from xml_harvard
                 text = re.sub(r"^<\?xml.*?\?>", "", text, count=1)
-                params["markup_text"] = text or ""
+                params["source_text"] = text or ""
+                params["has_markup"] = True
             else:
-                params["markup_text"] = row["plain_text"]
+                params["source_text"] = row["plain_text"]
 
-            found_citations = get_citations(**params)
+            document = Document(**params)
+            found_citations = get_citations(document)
 
             # Get the citation text string from the cite object
             cites = [cite.token.data for cite in found_citations if cite.token]

--- a/eyecite/__init__.py
+++ b/eyecite/__init__.py
@@ -1,6 +1,7 @@
 from .annotate import annotate_citations
 from .clean import clean_text
 from .find import get_citations
+from .models import Document
 from .resolve import resolve_citations
 
 __all__ = [
@@ -8,6 +9,7 @@ __all__ = [
     "get_citations",
     "clean_text",
     "resolve_citations",
+    "Document",
 ]
 
 # No need to create API documentation for these internal helper functions

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -495,11 +495,14 @@ def find_html_tags_at_position(
         List of tuples containing (tag_name, start_pos, end_pos)
         Empty list if no matching tags found
     """
-    markup_loc = document.plain_to_markup.update(  # type: ignore
+    if not document.has_markup:
+        return []
+
+    markup_loc = document.cleaned_to_source.update(  # type: ignore
         position,
         bisect_right,
     )
-    tags = [r for r in document.emphasis_tags if r[1] <= markup_loc < r[2]]
+    tags = [r for r in document.emphasis_tags if r[1] <= markup_loc < r[2]]  # type: ignore
     if len(tags) != 1:
         return []
     return tags
@@ -838,15 +841,15 @@ def convert_html_to_plain_text_and_loc(
     """
     markup_location = results[0]
 
-    start = document.markup_to_plain.update(  # type: ignore
+    start = document.source_to_cleaned.update(  # type: ignore
         markup_location[1],
         bisect_right,
     )
-    end = document.markup_to_plain.update(  # type: ignore
+    end = document.source_to_cleaned.update(  # type: ignore
         markup_location[2],
         bisect_right,
     )
-    case_name = document.plain_text[start:end]
+    case_name = document.cleaned_text[start:end]
     return (case_name, start, end)
 
 

--- a/eyecite/utils.py
+++ b/eyecite/utils.py
@@ -317,7 +317,7 @@ def maybe_balance_style_tags(
     return start, end, plain_text[start:end]
 
 
-def placeholder_markup(html: str) -> str:
+def create_placeholder_markup(html: str) -> str:
     """Create placeholder HTML to identify annotation locations.
 
     This allows diffing or annotation algorithms to maintain correct

--- a/tests/test_CourtsTest.py
+++ b/tests/test_CourtsTest.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from eyecite import get_citations
+from eyecite.models import Document
 
 
 class RegexesTest(TestCase):
@@ -38,5 +39,5 @@ class RegexesTest(TestCase):
             "Wallace v. Cellco P'ship, No. CV 14-8052-DSF (AS), 2015 WL 13908106, at *7 (C.D. Cal. Feb. 9, 2015)": "cacd",
         }
         for key in samples:
-            eyecite_result = get_citations(key)
+            eyecite_result = get_citations(Document(key))
             self.assertEqual(eyecite_result[0].metadata.court, samples[key])

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from eyecite import get_citations
-from eyecite.models import Resource
+from eyecite.models import Document, Resource
 from eyecite.test_factories import (
     case_citation,
     id_citation,
@@ -98,8 +98,8 @@ class ModelsTest(TestCase):
         """Are two citation objects equal when their attributes are
         the same, even if one of them has a nominative reporter?"""
         citations = [
-            get_citations("5 U.S. 137")[0],
-            get_citations("5 U.S. (1 Cranch) 137")[0],
+            get_citations(Document("5 U.S. 137"))[0],
+            get_citations(Document("5 U.S. (1 Cranch) 137"))[0],
         ]
         print(
             "Testing citation comparison with nominative reporter...", end=" "
@@ -128,8 +128,8 @@ class ModelsTest(TestCase):
         the same, even if they are tax court citations and might not
         have volumes?"""
         citations = [
-            get_citations("T.C.M. (RIA) ¶ 95,342")[0],
-            get_citations("T.C.M. (RIA) ¶ 95,342")[0],
+            get_citations(Document("T.C.M. (RIA) ¶ 95,342"))[0],
+            get_citations(Document("T.C.M. (RIA) ¶ 95,342"))[0],
         ]
         print("Testing tax court citation comparison...", end=" ")
         self.assertEqual(citations[0], citations[1])
@@ -163,7 +163,7 @@ class ModelsTest(TestCase):
         attribute set to None?"""
 
         citation1 = case_citation(2, volume="2", reporter="U.S.", page="__")
-        citation2 = get_citations("2 U.S. __")[0]
+        citation2 = get_citations(Document("2 U.S. __"))[0]
         print("Testing missing page conversion...", end=" ")
         self.assertIsNone(citation1.groups["page"])
         self.assertIsNone(citation2.groups["page"])
@@ -207,7 +207,9 @@ class ModelsTest(TestCase):
         """Does the corrected_citation_full method return a properly formatted
         citation?"""
         journal_citation = get_citations(
-            "Originalism without Foundations, 65 N.Y.U. L. Rev. 1373 (1990)"
+            Document(
+                "Originalism without Foundations, 65 N.Y.U. L. Rev. 1373 (1990)"
+            )
         )[0]
         self.assertEqual(
             journal_citation.corrected_citation_full(),
@@ -215,7 +217,7 @@ class ModelsTest(TestCase):
         )
 
         full_case_citation = get_citations(
-            "Meritor Sav. Bank v. Vinson, 477 U.S. 57, 60 (1986)"
+            Document("Meritor Sav. Bank v. Vinson, 477 U.S. 57, 60 (1986)")
         )[0]
         self.assertEqual(
             full_case_citation.corrected_citation_full(),
@@ -242,7 +244,7 @@ class ModelsTest(TestCase):
             ),
         ]
         for citation, corrected_citation, corrected_page in tests:
-            cite = get_citations(citation)[0]
+            cite = get_citations(Document(citation))[0]
             self.assertEqual(
                 cite.corrected_citation(),
                 corrected_citation,

--- a/tests/test_ResolveTest.py
+++ b/tests/test_ResolveTest.py
@@ -52,10 +52,8 @@ class ResolveTest(TestCase):
             None
         """
 
-        document = Document(
-            plain_text=citation_text,
-        )
-        citations = get_citations(citation_text)
+        document = Document(citation_text)
+        citations = get_citations(document)
         if resolved_case_name_short:
             citations[
                 0
@@ -127,7 +125,7 @@ class ResolveTest(TestCase):
 
         for i, cite_text in expected_resolutions:
             # extract cite and make sure there's only one:
-            cites = get_citations(cite_text)
+            cites = get_citations(document=Document(cite_text))
             self.assertEqual(
                 len(cites),
                 1,

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 from unittest import TestCase
 
 from eyecite import clean_text, get_citations
+from eyecite.models import Document
 from eyecite.utils import dump_citations
 
 
@@ -34,7 +35,7 @@ class UtilsTest(TestCase):
 
     def test_dump_citations(self):
         text = "blah. Foo v. Bar, 1 U.S. 2, 3-4 (1999). blah"
-        cites = get_citations(text)
+        cites = get_citations(Document(text))
         dumped_text = dump_citations(cites, text)
         dumped_text = re.sub(r"\x1B.*?m", "", dumped_text)  # strip colors
         expected = dedent(


### PR DESCRIPTION
In #240, @flooie introduced a new `Document` class to better keep track of any markup and cleaning steps applied to the text given to eyecite for parsing. However, the class is currently only used internally, meaning that it is still pretty confusing for the user (in my opinion) to keep track of what parameters they should be passing when.

For example, `get_citations()` currently accepts both a `plain_text` and a `markup_text` parameter, but both are typed optional. So can the user choose which of these to pass, or is the user always supposed to pass `plain_text` no matter what? If `markup_text` exists, should it be passed in addition to `plain_text`, or instead of it? Should `plain_text` still be cleaned by the user in advance? But isn't the `Document` abstraction supposed to keep track of the cleaning steps now? Or is that cleaning stage only cleaning for `markup_text`, and if there's other cleaning to be done, the user should still handle that in advance? And when the user later calls `annotate_citations()`, they're supposed to remember what the original `plain_text` was (along with the `source_text`, an entirely new variable?), and pass some combination of it all over again?

This PR attempts to resolve these confusions by simply exposing the internal `Document` model to the user. The idea is that the user should always instantiate a `Document` himself, and then just pass *that object* to `get_citations()` and `annotate_citations()`. All the pre-processing related parameters (whether the text has markup, any cleaning steps, what diffing algorithm to use, etc.) are dealt with only *once* at the `Document` level and then never needed again (from the user's perspective).

So with this PR, for example, the user would do:

```
from eyecite import get_citations, annotate_citations, Document

document = Document(
    opinion_text,
    has_markup=True,
    clean_steps=["html", "all_whitespace"]
)
citations = get_citations(document)
linked_text = annotate_citations(
     document,
     annotations=[[c.span(), "<a>", "</a>"] for c in citations]
)
```

Instead of (current syntax):

```
from eyecite import get_citations, annotate_citations, clean_text

markup_text = opinion_text
plain_text = clean_text(markup_text, steps=["html", "all_whitespace"])  # I think?

citations = get_citations(
    plain_text=plain_text,
    markup_text=markup_text,
    clean_steps=["html", "all_whitespace"]
)
linked_text = annotate_citations(
    plain_text = plain_text,
    source_text = markup_text
    annotations=[[c.span(), "<a>", "</a>"] for c in citations]
)
```

This PR is purely refactoring the ergonomics of the API -- it doesn't change any functionality. (The changes to the tests are just syntactical.) I think it's an improvement, but I recognize that breaking the API is always controversial, so open to discussion. And I think the idea to introduce the `Document` abstraction in the first place is great.

Some other documentation improvement-related PRs to follow soon as well.