### PR TITLE
Fixes AhocorasickTokenizer regex replace for API docs

### DIFF
--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Run sed  # Removes insanely-long parameter definition from docs
         working-directory: ./api_documentation
         run: |
-          sed -i 's/AhocorasickTokenizer(.*\]))/AhocorasickTokenizer()/' ./eyecite/find.html
-          sed -i 's/AhocorasickTokenizer(.*\]))/AhocorasickTokenizer()/' ./eyecite/index.html
+          sed -i 's/AhocorasickTokenizer(.*\])\)/AhocorasickTokenizer()/' ./eyecite/find.html
+          sed -i 's/AhocorasickTokenizer(.*\])\)/AhocorasickTokenizer()/' ./eyecite/index.html
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Changes:
   This shouldn’t have any visible impact to users, except from a few small metadata changes.
 
 Fixes:
--
+- Fixes rendering of AhocorasickTokenizer parameter definition in API docs #279
 
 ## Current
 

--- a/api_documentation/generate_documentation.sh
+++ b/api_documentation/generate_documentation.sh
@@ -6,5 +6,5 @@
 
 (pip3 install pdoc3);
 (pdoc --html $(pwd)/../eyecite --output-dir $(pwd) --force);
-(sed -i '' 's/AhocorasickTokenizer(.*\]))/AhocorasickTokenizer()/' $(pwd)/eyecite/find.html)  # Removes insanely-long parameter definition
-(sed -i '' 's/AhocorasickTokenizer(.*\]))/AhocorasickTokenizer()/' $(pwd)/eyecite/index.html)  # Removes insanely-long parameter definition
+(sed -i '' 's/AhocorasickTokenizer(.*\])\)/AhocorasickTokenizer()/' $(pwd)/eyecite/find.html)  # Removes insanely-long parameter definition
+(sed -i '' 's/AhocorasickTokenizer(.*\])\)/AhocorasickTokenizer()/' $(pwd)/eyecite/index.html)  # Removes insanely-long parameter definition


### PR DESCRIPTION
When `pdoc` creates our API docs, it automatically pulls in info for each parameter definition. This is a problem in the `get_citations()` doc because the `AhocorasickTokenizer` definition is crazy long. (See problem here: https://freelawproject.github.io/eyecite/#eyecite.get_citations.)

Therefore, we have a hack where we remove (using `sed`) this text from the docs after `pdoc` is run. However, this apparently stopped working at some point. The problem is that one of the parentheses in the regex is not escaped, which must now be required. This simple PR fixes this issue.