### PR TITLE
Fix search for defendant name after stopword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Changes:
 
 Fixes:
 - Fixes rendering of AhocorasickTokenizer parameter definition in API docs #279
+- Fix for parsing defendant name causing crash
 
 ## Current
 

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -770,7 +770,7 @@ def _extract_defendant_after_stopword(
         None - updates citation object in place, or None if extraction fails
     """
     shift = 3
-    while words[index + shift] == " ":
+    while index + shift < len(words) and words[index + shift] == " ":
         shift += 1
 
     right_offset = len("".join([str(w) for w in words[index : index + shift]]))

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -825,6 +825,10 @@ class FindTest(TestCase):
                             ),
               reference_citation("Bivens", metadata={"plaintiff": "Bivens", "pin_cite": "at 122"})],
              {'clean_steps': ['html', 'inline_whitespace']}),
+            # Fix for index error when searching for case name
+            ("<p>State v. Luna-Benitez (S53965). Alternative writ issued, dismissed, 342 Or 255</p>",
+            [case_citation(volume="342", reporter="Or", page="255")],
+            {'clean_steps': ['html', 'inline_whitespace']})
         )
 
         # fmt: on


### PR DESCRIPTION
Add check that loop does not go beyond all words