### PR TITLE
chore: Bump version to 2.7.6 and update changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,14 +8,25 @@ Features:
 -
 
 Changes:
+-
+
+Fixes:
+-
+
+## Current
+
+**2.7.6 - 2025-06-25**
+
+Features:
+-
+
+Changes:
 - Move dependency management to uv.
   This shouldn’t have any visible impact to users, except from a few small metadata changes.
 
 Fixes:
 - Fixes rendering of AhocorasickTokenizer parameter definition in API docs #279
 - Fix for parsing defendant name causing crash
-
-## Current
 
 **2.7.5 - 2025-05-22**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "eyecite"
-version = "2.7.5"
+version = "2.7.6"
 description = "Tool for extracting legal citations from text strings."
 readme = "README.rst"
 keywords = ["legal", "courts", "citations", "extraction", "cites"]

--- a/uv.lock
+++ b/uv.lock
@@ -72,7 +72,7 @@ wheels = [
 
 [[package]]
 name = "eyecite"
-version = "2.7.5"
+version = "2.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "courts-db" },


### PR DESCRIPTION
This pull request includes updates to the changelog and versioning for the upcoming release of version 2.7.6. The most important changes include the addition of a new "Current" section in the `CHANGES.md` file and the version bump in `pyproject.toml`.

### Changelog updates:
* Added a new "Current" section for version 2.7.6 in `CHANGES.md`, including placeholders for "Features," "Changes," and "Fixes" to organize future updates. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R10-R22) [[2]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L18-L19)

### Versioning updates:
* Updated the version number from `2.7.5` to `2.7.6` in `pyproject.toml`.