### PR TITLE
fix(docs): Update regex for long pattern in docs

### DIFF
--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -35,8 +35,7 @@ jobs:
       - name: Run sed  # Removes insanely-long parameter definition from docs
         working-directory: ./api_documentation
         run: |
-          sed -i 's/AhocorasickTokenizer(.*\])\)/AhocorasickTokenizer()/' ./eyecite/find.html
-          sed -i 's/AhocorasickTokenizer(.*\])\)/AhocorasickTokenizer()/' ./eyecite/index.html
+          sed -i '' -E 's#(AhocorasickTokenizer\().*(markup_text:)#\1),<br>\2#g' eyecite/find.html eyecite/index.html
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
 -
 
 Fixes:
--
+- Modifies rendering of AhocorasickTokenizer parameter in API docs II
 
 ## Current
 

--- a/api_documentation/generate_documentation.sh
+++ b/api_documentation/generate_documentation.sh
@@ -6,5 +6,4 @@
 
 (pip3 install pdoc3);
 (pdoc --html $(pwd)/../eyecite --output-dir $(pwd) --force);
-(sed -i '' 's/AhocorasickTokenizer(.*\])\)/AhocorasickTokenizer()/' $(pwd)/eyecite/find.html)  # Removes insanely-long parameter definition
-(sed -i '' 's/AhocorasickTokenizer(.*\])\)/AhocorasickTokenizer()/' $(pwd)/eyecite/index.html)  # Removes insanely-long parameter definition
+sed -i '' -E 's#(AhocorasickTokenizer\().*(markup_text:)#\1),<br>\2#g' eyecite/find.html eyecite/index.html


### PR DESCRIPTION
The recent update to the parameter removal failed in GitHub actions and locally. 

I made a small change with the hope that it will succeed.  @mattdahl do you mind taking a look.