### PR TITLE
fix(tokenizer): Don't drop nominative reporter due to overlapping CitationTokens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
 
 Fixes:
 - Modifies rendering of AhocorasickTokenizer parameter in API docs II
+- Fixes dropping of nominative reporter due to overlapping CitationTokens
 
 ## Current
 


### PR DESCRIPTION
I found that eyecite was not parsing "Calderon v. Thompson, 523 U.S. 538" correctly because Thompson is also a nominative reporter.

```
>>> text = "Calderon v. Thompson, 523 U.S. 538"
>>> cite = eyecite.get_citations(text)[0]
>>> cite
FullCaseCitation('523 U.S. 538', groups={'volume': '523', 'reporter': 'U.S.', 'page': '538'}, metadata=FullCaseCitation.Metadata(parenthetical=None, pin_cite=None, pin_cite_span_start=None, pin_cite_span_end=None, year=None, month=None, day=None, court='scotus', plaintiff='', defendant='Calderon', extra=None, antecedent_guess=None, resolved_case_name_short=None, resolved_case_name=None))

>>> text[cite.full_span()[0]:cite.full_span()[1]]
'. Thompson, 523 U.S. 538'
```

(I used AI to help me with fixing this bug). The issue appears to be that when we have a token overlap, and we drop the token with the nominative reporter, the nominative reporter is no longer accounted for by any token.