### PR TITLE
fix(plaintiff parsing): stop removing lowercase words in plaintiff name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
 
 Fixes:
 - Modifies rendering of AhocorasickTokenizer parameter in API docs II
+- No longer removing lowercase words from plaintiff
 
 ## Current
 

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -363,8 +363,7 @@ def _process_case_name(
         else:
             plaintiff, defendant = "", splits[0]
         plaintiff = plaintiff.strip(f"{whitespace},(")
-        clean_plaintiff = re.sub(r"\b[a-z]\w*\b", "", plaintiff)
-        plaintiff = strip_stop_words(clean_plaintiff)
+        plaintiff = strip_stop_words(plaintiff)
         citation.metadata.plaintiff = plaintiff
     else:
         defendant = candidate_case_name

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -828,7 +828,14 @@ class FindTest(TestCase):
             # Fix for index error when searching for case name
             ("<p>State v. Luna-Benitez (S53965). Alternative writ issued, dismissed, 342 Or 255</p>",
             [case_citation(volume="342", reporter="Or", page="255")],
-            {'clean_steps': ['html', 'inline_whitespace']})
+            {'clean_steps': ['html', 'inline_whitespace']}),
+            # Previously, this test would fail because lowercase words were removed from
+            # the plaintiff name.
+            ('City of Davis v. Coleman, 521 F.2d 661 (9th Cir. 1975)',
+             [case_citation(volume='521', reporter='F.2d', page='661', year=1975,
+                            metadata={'plaintiff': 'City of Davis',
+                                      'defendant': 'Coleman',
+                                      'court': 'ca9'})])
         )
 
         # fmt: on


### PR DESCRIPTION
in #241 there was a line added to remove all lowercase words from plaintiff names. I'm not entirely clear why it was added but it does remove valid parts of plaintiff names!