### PR TITLE
fix(extraction): Handle sequential citations better

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Features:
 -
 
 Changes:
--
+- Handle sequential citations (in close proximity) better
 
 Fixes:
 - Modifies rendering of AhocorasickTokenizer parameter in API docs II

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -828,7 +828,13 @@ class FindTest(TestCase):
             # Fix for index error when searching for case name
             ("<p>State v. Luna-Benitez (S53965). Alternative writ issued, dismissed, 342 Or 255</p>",
             [case_citation(volume="342", reporter="Or", page="255")],
-            {'clean_steps': ['html', 'inline_whitespace']})
+            {'clean_steps': ['html', 'inline_whitespace']}),
+            # Sequential full case citations.
+            ("West v. Atkins, 487 U.S. 42, 54-58 (1988), Polk Cty. v. Dodson, 454 U.S. 312, 325-26 (1981), and Monell v. Department of Soc. Servs., 436 U.S. 658, 694 (1978)",
+             [case_citation(volume="487", reporter="U.S.", page="42", metadata={"plaintiff": "West", "defendant": "Atkins", "year": "1988", "pin_cite": "54-58"}),
+              case_citation(volume="454", reporter="U.S.", page="312", metadata={"plaintiff": "Polk Cty.", "defendant": "Dodson", "year": "1981", "pin_cite": "325-26"}),
+              case_citation(volume="436", reporter="U.S.", page="658", metadata={"plaintiff": "Monell", "defendant": "Department of Soc. Servs.", "year": "1978", "pin_cite": "694"}),
+             ]),
         )
 
         # fmt: on


### PR DESCRIPTION
When two citations are right next to each other (i.e., within BACKWARD_SEEK), the citation extraction can be wrong.

I was testing with the string `West v. Atkins, 487 U.S. 42, 54-58 (1988), Polk Cty. v. Dodson, 454 U.S. 312, 325-26 (1981), and Monell v. Department of Soc. Servs., 436 U.S. 658, 694 (1978)`

Before this fix, the second and third citations would have missing plaintiff, defendant, and pincite. Now with this small fix, those three fields are populated correctly.

I'm not super happy with this fix, but it doesn't break any tests and it'll be helpful for me. Sharing this PR here in case it's of interest or if you have better ideas for how to fix.

The main thing I'm not happy with is `word_str.endswith("),")`, which feels too tightly coupled to the specific example I have. But I'm going to move on for now and I'll come back to this when/if I find more real-life examples.