### PR TITLE
fix(citation): Ensure full_span is aligned for parallel citations, fix full_span_end

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
 
 Fixes:
 - Modifies rendering of AhocorasickTokenizer parameter in API docs II
+- Fixes full_span_end not always being the same among parallel citations
 
 ## Current
 

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -507,8 +507,6 @@ class FullCaseCitation(CaseCitation, FullCitation):
             # California style may have a year prior to citation; merge as well
             self.metadata.year = preceding.metadata.year
             self.year = preceding.year
-            # Parallel citations should have the same full_span_end
-            # self.full_span_end = preceding.full_span_end
 
     @dataclass(eq=True, unsafe_hash=True)
     class Metadata(CaseCitation.Metadata):

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -507,6 +507,8 @@ class FullCaseCitation(CaseCitation, FullCitation):
             # California style may have a year prior to citation; merge as well
             self.metadata.year = preceding.metadata.year
             self.year = preceding.year
+            # Parallel citations should have the same full_span_end
+            self.full_span_end = preceding.full_span_end
 
     @dataclass(eq=True, unsafe_hash=True)
     class Metadata(CaseCitation.Metadata):

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -508,7 +508,7 @@ class FullCaseCitation(CaseCitation, FullCitation):
             self.metadata.year = preceding.metadata.year
             self.year = preceding.year
             # Parallel citations should have the same full_span_end
-            self.full_span_end = preceding.full_span_end
+            # self.full_span_end = preceding.full_span_end
 
     @dataclass(eq=True, unsafe_hash=True)
     class Metadata(CaseCitation.Metadata):

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -308,7 +308,7 @@ POST_FULL_CITATION_REGEX = rf"""
         [\(\[] # opening paren or bracket
         (?:
             (?:
-                (?P<court>.*?) # treat anything before date as court
+                (?P<court>[^)]*?) # treat anything before date as court
                 (?= # lookahead to stop when we see a month or year
                     \s+{MONTH_REGEX} |
                     \s+{YEAR_REGEX}

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -308,7 +308,7 @@ POST_FULL_CITATION_REGEX = rf"""
         [\(\[] # opening paren or bracket
         (?:
             (?:
-                (?P<court>[^)]*?) # treat anything before date as court
+                (?P<court>[^)\]]*?) # treat anything before date as court
                 (?= # lookahead to stop when we see a month or year
                     \s+{MONTH_REGEX} |
                     \s+{YEAR_REGEX}

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -1203,12 +1203,11 @@ class FindTest(TestCase):
         the current citation. However, we can trust that the post citation matching
         worked correctly for the first of the parallel citations.
         """
-        text = "Kaiser Steel Corp. v. W.S. Ranch Co., 391 U.S. 593, 598, 88 S. Ct. 1753, 20 L.Ed.2d 835 (1968). We have previously held that the automatic stay provisions of the Bankruptcy Code may toll the statute of limitations under the Warsaw Convention, which is the precursor to the Montreal Convention. See Zicherman v. Korean Air Lines Co., Ltd., 516 F.3d 1237, 1254 (11th Cir. 2008)"
+        text = "Kaiser Steel Corp. v. W.S. Ranch Co., 391 U.S. 593, 598, 88 S. Ct. 1753, 20 L.Ed.2d 835 (1968). We have previously held that the automatic stay provisions of the Bankruptcy Code may toll the statute the Montreal Convention. See Zicherman v. Korean Air Lines Co., Ltd., 516 F.3d 1237, 1254 (11th Cir. 2008)"
         citations = get_citations(text)
-        full_span_end = citations[0].full_span_end
-        self.assertEqual(citations[0].full_span_end, full_span_end)
-        self.assertEqual(citations[1].full_span_end, full_span_end)
-        self.assertEqual(citations[2].full_span_end, full_span_end)
+        self.assertEqual(citations[0].full_span_end, 94)
+        self.assertEqual(citations[1].full_span_end, 94)
+        self.assertEqual(citations[2].full_span_end, 94)
 
     def test_reference_extraction_using_resolved_names(self):
         """Can we extract a reference citation using resolved metadata?"""

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -828,7 +828,7 @@ class FindTest(TestCase):
             # Fix for index error when searching for case name
             ("<p>State v. Luna-Benitez (S53965). Alternative writ issued, dismissed, 342 Or 255</p>",
             [case_citation(volume="342", reporter="Or", page="255")],
-            {'clean_steps': ['html', 'inline_whitespace']})
+            {'clean_steps': ['html', 'inline_whitespace']}),
         )
 
         # fmt: on
@@ -1193,6 +1193,22 @@ class FindTest(TestCase):
             self.assertEqual(
                 extracted.full_span(), (start_idx, len(sentence)), error_msg
             )
+
+    def test_parallel_full_span(self):
+        """Parallel citations should have the same full_span_end
+
+        Note: it seems that the full_span_end can sometimes differ for a parallel
+        citation due to the way POST_FULL_CITATION_REGEX is defined. Under certain
+        conditions, it can end up matching to the next citation as opposed to the end of
+        the current citation. However, we can trust that the post citation matching
+        worked correctly for the first of the parallel citations.
+        """
+        text = "Kaiser Steel Corp. v. W.S. Ranch Co., 391 U.S. 593, 598, 88 S. Ct. 1753, 20 L.Ed.2d 835 (1968). We have previously held that the automatic stay provisions of the Bankruptcy Code may toll the statute of limitations under the Warsaw Convention, which is the precursor to the Montreal Convention. See Zicherman v. Korean Air Lines Co., Ltd., 516 F.3d 1237, 1254 (11th Cir. 2008)"
+        citations = get_citations(text)
+        full_span_end = citations[0].full_span_end
+        self.assertEqual(citations[0].full_span_end, full_span_end)
+        self.assertEqual(citations[1].full_span_end, full_span_end)
+        self.assertEqual(citations[2].full_span_end, full_span_end)
 
     def test_reference_extraction_using_resolved_names(self):
         """Can we extract a reference citation using resolved metadata?"""


### PR DESCRIPTION
It seems that the full_span_end can sometimes differ for a parallel citation due to the way POST_FULL_CITATION_REGEX is defined. Under certain conditions, it can end up matching to the next citation as opposed to the end of the current citation. However, we can trust that the post citation matching worked correctly for the first of the parallel citations.

The example I came across is "Kaiser Steel Corp. v. W.S. Ranch Co., 391 U.S. 593, 598, 88 S. Ct. 1753, 20 L.Ed.2d 835 (1968). We have previously held that the automatic stay provisions of the Bankruptcy Code may toll the statute of limitations under the Warsaw Convention, which is the precursor to the Montreal Convention. See Zicherman v. Korean Air Lines Co., Ltd., 516 F.3d 1237, 1254 (11th Cir. 2008)"

The third of the three parallel citations has a full_span_end that goes all the way to the end of the text. I think it's because POST_FULL_CITATATION_REGEX ends up matching with the citation at the end of the text.