### PR TITLE
Exclude star-pagination text when extracting citations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
 
 Fixes:
 - Modifies rendering of AhocorasickTokenizer parameter in API docs II
+- Removed star-pagination markers from extracted text #293
 
 ## Current
 

--- a/eyecite/clean.py
+++ b/eyecite/clean.py
@@ -51,7 +51,9 @@ def html(html_content: str) -> str:
             parent::link |
             parent::head |
             parent::page-number |
-            parent::script)]"""
+            parent::script |
+            parent::*[@class="star-pagination"]
+            )]"""
     )
     return " ".join(text)
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -828,7 +828,14 @@ class FindTest(TestCase):
             # Fix for index error when searching for case name
             ("<p>State v. Luna-Benitez (S53965). Alternative writ issued, dismissed, 342 Or 255</p>",
             [case_citation(volume="342", reporter="Or", page="255")],
-            {'clean_steps': ['html', 'inline_whitespace']})
+            {'clean_steps': ['html', 'inline_whitespace']}),
+            # Test remove text with star-pagination class
+            ("<p>The somewhat similar cases of <i>Crane</i> v. <i>Hyde Park,</i> 135 <span class=\"star-pagination\">*355</span> Mass. 147, and <i>Mahoning County</i> v. <i>Young,</i> 16 U.S. App. 253, also cited by the defendant, likewise turned upon a question of forfeiture for breach of a condition subsequent in a deed to a municipal corporation.</p>",
+             [case_citation(volume="135", reporter="Mass.", page="147",
+                            metadata={"plaintiff": "Crane",
+                                      "defendant": "Hyde Park"}
+                            )],
+             {'clean_steps': ['html', 'inline_whitespace']})
         )
 
         # fmt: on


### PR DESCRIPTION
This PR updates the XPath used for text extraction to ignore text nodes whose parent has the star-pagination class. These markers should not be included in the cleaned content. These are used in Harvard's XML.

**Example:**

Input: `135 <span class="star-pagination">*355</span> Mass. 147`

**Before:**
Extracted text included pagination markers:

Output: `355 Mass. 147`

**After:**
Pagination markers are excluded:

Output: `135 Mass. 147`