### PR TITLE
feat(tokenizers): relax inter-token whitespace when matching reporter abbreviations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 The following changes are not yet released, but are code complete:
 
 Features:
--
+- Relax inter-token whitespace when matching reporter abbreviations, so spaced-out print forms like `123 N. Y. S. 2d 456` match the compact `N.Y.S.2d` in reporters-db. Periods stay mandatory. #305
 
 Changes:
 -

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -92,6 +92,44 @@ def token_is_from_nominative_reporter(token: Token) -> bool:
     return name in NOMINATIVE_REPORTER_NAMES
 
 
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _relax_ws(escaped: str) -> str:
+    """Relax inter-token whitespace in an escaped reporter abbreviation.
+
+    ``re.escape`` turns a reporter string into an exact-match pattern in which
+    each period matches a literal period and each space matches exactly one
+    space. That makes the spaced-out print style common in older/official
+    reporters fail to match: ``N.Y.S.2d`` is in reporters-db, but the same
+    citation as printed -- ``N. Y. S. 2d`` -- is not recognized.
+
+    This makes the whitespace *between* abbreviation tokens flexible while
+    keeping periods mandatory, so a single canonical reporter string matches
+    all of its respaced forms (e.g. ``N.Y.S.2d`` also matches ``N. Y. S. 2d``
+    and ``N.Y.S. 2d``; ``Ohio C.C.`` also matches ``Ohio  C. C.``).
+
+    See https://github.com/freelawproject/eyecite/issues/305.
+    """
+    # period -> period followed by optional whitespace
+    escaped = escaped.replace(r"\.", r"\.\s*")
+    # one or more literal spaces -> optional whitespace.
+    # (`re.escape` escapes a space as "\ "; match it with or without the
+    # backslash so this is robust across Python versions.)
+    escaped = re.sub(r"(?:\\?\ )+", r"\\s*", escaped)
+    return escaped
+
+
+def _strip_ws(text: str) -> str:
+    """Remove all whitespace from ``text``.
+
+    Used by :class:`AhocorasickTokenizer` to match its whitespace-insensitive
+    reporter prefilter strings against text that may use a spaced-out print
+    style. See :func:`_relax_ws`.
+    """
+    return _WHITESPACE_RE.sub("", text)
+
+
 def _populate_reporter_extractors():
     """Populate EXTRACTORS and EDITIONS_LOOKUP."""
 
@@ -103,7 +141,7 @@ def _populate_reporter_extractors():
 
     def _substitute_edition(template, *edition_names):
         """Helper to replace $edition in template with edition_names."""
-        edition = "|".join(re.escape(e) for e in edition_names)
+        edition = "|".join(_relax_ws(re.escape(e)) for e in edition_names)
         return Template(template).safe_substitute(edition=edition)
 
     # Extractors step one: add an extractor for each reporter string
@@ -143,7 +181,9 @@ def _populate_reporter_extractors():
         editions_by_regex[regex][kind].append(edition)
 
         # add strings
-        have_strings = re.escape(reporters[0]) in regex
+        # The reporter is embedded in `regex` with relaxed inter-token
+        # whitespace (see _relax_ws), so check for the relaxed form.
+        have_strings = _relax_ws(re.escape(reporters[0])) in regex
         if have_strings:
             editions_by_regex[regex]["strings"].update(reporters)
 
@@ -419,16 +459,22 @@ class AhocorasickTokenizer(Tokenizer):
         """Set up helpers to narrow down possible extractors."""
         # Build a set of all extractors that don't list required strings
         self.unfiltered_extractors = {e for e in EXTRACTORS if not e.strings}
+        # Build the filters from whitespace-stripped prefilter strings, and
+        # match them against a whitespace-stripped copy of the text (see
+        # get_extractors). Reporter regexes allow flexible inter-token
+        # whitespace (see _relax_ws), so e.g. "N. Y. S. 2d" must still select
+        # the "N.Y.S.2d" extractor. Stripping whitespace from both sides keeps
+        # the prefilter a sound superset of the relaxed regexes' matches.
         # Build a pyahocorasick filter for all case-sensitive extractors
         self.case_sensitive_filter = self.make_ahocorasick_filter(
-            (s, e)
+            (_strip_ws(s), e)
             for e in EXTRACTORS
             if e.strings and not e.flags & re.I
             for s in e.strings
         )
         # Build a pyahocorasick filter for all case-insensitive extractors
         self.case_insensitive_filter = self.make_ahocorasick_filter(
-            (s.lower(), e)
+            (_strip_ws(s).lower(), e)
             for e in EXTRACTORS
             if e.strings and e.flags & re.I
             for s in e.strings
@@ -437,10 +483,17 @@ class AhocorasickTokenizer(Tokenizer):
     def get_extractors(self, text: str) -> set[TokenExtractor]:
         """Override get_extractors() to filter out extractors
         that can't possibly match."""
+        # Strip whitespace so spaced-out reporter forms (e.g. "N. Y. S. 2d")
+        # still match their compact prefilter strings ("N.Y.S.2d"). This is
+        # only used to select candidate extractors; the actual match spans
+        # come from running the extractors against the original text.
+        stripped = _strip_ws(text)
         unique_extractors = set(self.unfiltered_extractors)
-        for _, extractors in self.case_sensitive_filter.iter(text):
+        for _, extractors in self.case_sensitive_filter.iter(stripped):
             unique_extractors.update(extractors)
-        for _, extractors in self.case_insensitive_filter.iter(text.lower()):
+        for _, extractors in self.case_insensitive_filter.iter(
+            stripped.lower()
+        ):
             unique_extractors.update(extractors)
         return unique_extractors
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -878,6 +878,18 @@ class FindTest(TestCase):
             ('799 N.Y.S.2d 795',
              [case_citation(volume='799', page='795',
                             reporter='N.Y.S.2d')]),
+            # Short cite with a spaced reporter, which goes through the
+            # separate short_cite_re path. "N. Y. S. 2d" is not a registered
+            # variation, so it matches only via the whitespace relaxation --
+            # unlike the "U. S." short cites elsewhere in this file, which
+            # still pass through their reporters-db variation. Once those
+            # whitespace-only variations are removed (reporters-db #261),
+            # this relaxation becomes the only path for spaced short cites,
+            # so guard that short_cite_re composes with it.
+            ('See Adarand, 799 N. Y. S. 2d, at 797',
+             [case_citation(volume='799', page='797', reporter='N.Y.S.2d',
+                            reporter_found='N. Y. S. 2d', short=True,
+                            metadata={'antecedent_guess': 'Adarand'})]),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Relaxed reporter whitespace")

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -890,6 +890,17 @@ class FindTest(TestCase):
              [case_citation(volume='799', page='797', reporter='N.Y.S.2d',
                             reporter_found='N. Y. S. 2d', short=True,
                             metadata={'antecedent_guess': 'Adarand'})]),
+            # Law citations (laws.json) and journal citations (journals.json)
+            # build their regexes through the same chokepoint, so the
+            # relaxation applies to them too. Spaced "U. S. C." / "F. B. I. S."
+            # are not registered variations, so these only match via it.
+            ('18 U. S. C. § 4241',
+             [law_citation('18 U. S. C. § 4241', reporter='U.S.C.',
+                           reporter_found='U. S. C.',
+                           groups={'title': '18', 'section': '4241'})]),
+            ('1 F. B. I. S. 1',
+             [journal_citation('1 F. B. I. S. 1', reporter='F.B.I.S.',
+                               reporter_found='F. B. I. S.')]),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Relaxed reporter whitespace")

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -841,6 +841,47 @@ class FindTest(TestCase):
         # fmt: on
         self.run_test_pairs(test_pairs, "Citation extraction")
 
+    def test_relaxed_reporter_whitespace(self):
+        """Do we match reporters printed with extra inter-token whitespace?
+
+        Reporter abbreviations are stored compactly in reporters-db (e.g.
+        "N.Y.S.2d"), but the older/official print style spaces the tokens out
+        ("N. Y. S. 2d"). Whitespace between tokens is relaxed at match time
+        while periods stay mandatory. See #305.
+        """
+        # fmt: off
+        test_pairs = (
+            # Spaced single-letter reporters
+            ('123 N. Y. S. 2d 456',
+             [case_citation(volume='123', page='456',
+                            reporter='N.Y.S.2d',
+                            reporter_found='N. Y. S. 2d')]),
+            ('260 F. R. D. 38',
+             [case_citation(volume='260', page='38',
+                            reporter='F.R.D.',
+                            reporter_found='F. R. D.')]),
+            ('8 N. Y. 3d 204',
+             [case_citation(volume='8', page='204',
+                            reporter='N.Y.3d',
+                            reporter_found='N. Y. 3d')]),
+            # Partially spaced (space only after the final period)
+            ('799 N.Y.S. 2d 795',
+             [case_citation(volume='799', page='795',
+                            reporter='N.Y.S.2d',
+                            reporter_found='N.Y.S. 2d')]),
+            # Multi-word reporter with spaced tokens
+            ('31 Ohio C. C. 270',
+             [case_citation(volume='31', page='270',
+                            reporter='Ohio C.C.',
+                            reporter_found='Ohio C. C.')]),
+            # Compact forms still match unchanged
+            ('799 N.Y.S.2d 795',
+             [case_citation(volume='799', page='795',
+                            reporter='N.Y.S.2d')]),
+        )
+        # fmt: on
+        self.run_test_pairs(test_pairs, "Relaxed reporter whitespace")
+
     def test_find_law_citations(self):
         """Can we find citations from laws.json?"""
         # fmt: off

--- a/tests/test_TokenizeTest.py
+++ b/tests/test_TokenizeTest.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from reporters_db import REPORTERS
+
 from eyecite.models import CitationToken, IdToken, StopWordToken
 from eyecite.regexes import STOP_WORDS
 from eyecite.tokenizers import (
@@ -19,6 +21,11 @@ class TokenizerTest(TestCase):
             17,
             30,
             groups={"volume": "410", "reporter": "U. S.", "page": "113"},
+            # The spaced form "U. S." is both a registered variation and,
+            # since reporter whitespace is now relaxed (#305), an exact match
+            # for the canonical "U.S." edition. The two overlapping matches
+            # are merged into a single token.
+            exact_editions=(us_reporter,),
             variation_editions=(us_reporter,),
         )
         see_token = StopWordToken("See", 0, 3, "see")
@@ -90,14 +97,27 @@ class TokenizerTest(TestCase):
     def test_extractor_filter(self):
         """Does AhocorasickTokenizer only run the needed extractors?"""
         text = "See foo, 123 U.S. 456. Id."
-        # text should only require four extractors --
-        # stop token, US long cite, US short cite, id.
+        # text should only require the stop-word, id., and U.S. extractors:
+        # the canonical "U.S." edition (long + short cite) and its variations.
+        # The variations extractor is now selected too because reporter
+        # prefilter strings are matched whitespace-insensitively (#305), so
+        # variations like "U. S." also match the compact "U.S." in the text.
+        # `strings` is built from a set, so compare order-independently.
+        us_variations = frozenset(
+            variation
+            for variation, edition in REPORTERS["U.S."][0][
+                "variations"
+            ].items()
+            if edition == "U.S."
+        )
         expected_strings = {
-            STOP_WORDS,
-            ("U.S.",),
-            ("U.S.",),
-            ("id.", "ibid."),
+            frozenset(STOP_WORDS),
+            frozenset(["U.S."]),
+            us_variations,
+            frozenset(["id.", "ibid."]),
         }
         extractors = AhocorasickTokenizer().get_extractors(text)
-        extractor_strings = {tuple(e.strings) for e in extractors if e.strings}
+        extractor_strings = {
+            frozenset(e.strings) for e in extractors if e.strings
+        }
         self.assertEqual(expected_strings, extractor_strings)


### PR DESCRIPTION
Fixes #305

- Add _relax_ws helper: after re.escape, periods stay mandatory but inter-token whitespace becomes optional (N.Y.S.2d also matches N. Y. S. 2d).
- Apply at the single chokepoint _substitute_edition, so all reporter regexes (plain Tokenizer + production HyperscanTokenizer) pick it up for free.
- Fix AhocorasickTokenizer prefilter: match whitespace-stripped reporter strings against a whitespace-stripped copy of the text (selection only; real spans still come from the regex).
- Update _add_regex have_strings check to look for the relaxed form so prefilter strings still register.
- Scope: whitespace only — periods stay mandatory (avoids the +30 collision risk of dropping periods, e.g. MT→Mont.); +5 whitespace collisions, all rare/duplicate reporters.
- Tests: new test_relaxed_reporter_whitespace (single-letter, multi-word, partial, compact forms across all 3 tokenizers); updated test_reporter_tokenizer (U. S. now also an exact match) and test_extractor_filter.