### PR TITLE
fix(benchmark): correct inverted gains/losses and broken report table

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,12 +46,15 @@ jobs:
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
           echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
 
+      # branch1 = the PR (the repo is checked out at the PR ref here, so
+      # `env.main` resolves to the PR head sha). The baseline (main) is
+      # captured later as branch2, after we check main out.
       - name: Setup variables I
         id: branch1
         run: |
           echo ${{ github.event.issue.pull_request }}
-          echo "::set-output name=filepath::benchmark/${{ env.main }}.json"
-          echo "::set-output name=hash::${{ env.main }}"
+          echo "filepath=benchmark/${{ env.main }}.json" >> "$GITHUB_OUTPUT"
+          echo "hash=${{ env.main }}" >> "$GITHUB_OUTPUT"
       #----------------------------------------------
       #             Download Testing File
       #
@@ -94,16 +97,19 @@ jobs:
       - name: Install dependencies 2
         run: uv sync --frozen --no-group dev --group benchmark
 
+      # branch2 = main (we just checked it out above), i.e. the baseline.
       - name: Setup variables II
         id: branch2
         run: |
-          echo "::set-output name=filepath::benchmark/${{ env.main }}.json"
-          echo "::set-output name=hash::${{ env.main }}"
+          echo "filepath=benchmark/${{ env.main }}.json" >> "$GITHUB_OUTPUT"
+          echo "hash=${{ env.main }}" >> "$GITHUB_OUTPUT"
 
+      # Pass --base so gains/losses are oriented against main regardless of
+      # the order the two hashes appear in --branches.
       - name: Run second benchmark
         run: |
           git stash pop
-          python benchmark/benchmark.py --branches ${{ steps.branch1.outputs.hash }} ${{ steps.branch2.outputs.hash }} --pr ${{ github.event.number }}
+          python benchmark/benchmark.py --branches ${{ steps.branch1.outputs.hash }} ${{ steps.branch2.outputs.hash }} --base ${{ steps.branch2.outputs.hash }} --pr ${{ github.event.number }}
           mkdir results
           mv benchmark/output.csv benchmark/${{ steps.branch1.outputs.hash }}.json benchmark/${{ steps.branch2.outputs.hash }}.json benchmark/report.md benchmark/chart.png results/
 
@@ -174,7 +180,8 @@ jobs:
           curl https://storage.courtlistener.com/bulk-data/eyecite/tests/one-percent.csv.bz2 --output benchmark/bulk-file.csv.bz2
           python benchmark/benchmark.py --branches original
           uv pip install "git+https://github.com/freelawproject/reporters-db.git@${{ github.event.client_payload.commit }}"
-          python benchmark/benchmark.py --branches original update --reporters --pr ${{ github.event.client_payload.pr_number }}
+          # "original" is the baseline; "update" is the reporters-db PR.
+          python benchmark/benchmark.py --branches original update --base original --reporters --pr ${{ github.event.client_payload.pr_number }}
           mkdir results
           mv benchmark/output.csv benchmark/original.json benchmark/update.json benchmark/report.md benchmark/chart.png results/
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Run first benchmark
         run: |
           python benchmark/benchmark.py --branches ${{ steps.branch1.outputs.hash }}
+          # Preserve the PR's benchmark.py outside the working tree: the next
+          # step checks out main (clean: true), which would otherwise replace
+          # this script with main's version. The second run needs main's
+          # eyecite *library* for the baseline, but the PR's *script* so its
+          # report/CLI changes (e.g. --base) actually run.
+          cp benchmark/benchmark.py "$RUNNER_TEMP/benchmark.py"
           git stash --include-untracked
 
       - uses: actions/checkout@v4
@@ -109,6 +115,9 @@ jobs:
       - name: Run second benchmark
         run: |
           git stash pop
+          # Restore the PR's benchmark.py over main's checkout so the report
+          # generation and the --base flag come from the PR, not from main.
+          cp "$RUNNER_TEMP/benchmark.py" benchmark/benchmark.py
           python benchmark/benchmark.py --branches ${{ steps.branch1.outputs.hash }} ${{ steps.branch2.outputs.hash }} --base ${{ steps.branch2.outputs.hash }} --pr ${{ github.event.number }}
           mkdir results
           mv benchmark/output.csv benchmark/${{ steps.branch1.outputs.hash }}.json benchmark/${{ steps.branch2.outputs.hash }}.json benchmark/report.md benchmark/chart.png results/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Changes:
 Fixes:
 - Modifies rendering of AhocorasickTokenizer parameter in API docs II
 - Removed star-pagination markers from extracted text #293
+- Benchmark: fix inverted gains/losses, broken Markdown tables (citation
+  tokens with embedded newlines), and compare documents by id. Adds a net
+  citation-count summary. #212
 
 ## Current
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -22,7 +22,7 @@ csv.field_size_limit(sys.maxsize)
 
 root = Path(__file__).parent.absolute()
 
-MAX_ROWS_IN_MD = 51
+MAX_ROWS_IN_MD = 50
 
 
 class Benchmark:
@@ -79,50 +79,62 @@ class Benchmark:
         with open(self.get_filepath(f"{branch}.json"), "w") as f:
             json.dump(data, fp=f, indent=4)
 
+    @staticmethod
+    def _md_cell(value: str) -> str:
+        """Make a value safe to drop into a single Markdown table cell.
+
+        Some citation tokens contain embedded newlines (e.g.
+        ``"163 Ohio\\nSt.3d 242"``). A raw newline inside a table cell ends
+        the row -- and a blank line ends the whole table -- so the rendered
+        report breaks. Collapse any whitespace run (newlines included) to a
+        single space and escape the pipe that would otherwise start a new
+        column.
+        """
+        return re.sub(r"\s+", " ", value).replace("|", r"\|").strip()
+
     def write_report(self, repo, pr_number):
         """Begin building Report.MD file
 
         :return: None
         """
+        stats = getattr(self, "stats", {})
+        gains = stats.get("gains", 0)
+        losses = stats.get("losses", 0)
+        base_total = stats.get("base_total")
+        pr_total = stats.get("pr_total")
+
+        # Column widths (min 6) are computed from the *sanitized* cells, so
+        # they reflect what is actually rendered.
         max_gain, max_loss = 6, 6
-        gains, losses = 0, 0
-        with open("benchmark/output.csv") as inp:
-            reader = csv.DictReader(inp)
-            for row in reader:
-                if row["Gain"]:
-                    gains += 1
-                    max_gain = (
-                        len(row["Gain"])
-                        if len(row["Gain"]) > max_gain
-                        else max_gain
-                    )
-                if row["Loss"]:
-                    losses += 1
-                    max_loss = (
-                        len(row["Loss"])
-                        if len(row["Loss"]) > max_loss
-                        else max_loss
-                    )
+        with open(self.get_filepath("output.csv")) as inp:
+            for row in csv.DictReader(inp):
+                max_gain = max(max_gain, len(self._md_cell(row["Gain"])))
+                max_loss = max(max_loss, len(self._md_cell(row["Loss"])))
 
         with open(self.get_filepath("report.md"), "w") as f:
             f.write("# The Eyecite Report :eye:\n\n")
             f.write("\n\nGains and Losses\n")
             f.write("---------\n")
             f.write(f"There were {gains} gains and {losses} losses.\n")
+            if base_total is not None and pr_total is not None:
+                f.write(
+                    f"\nTotal citations found: base **{base_total}**, "
+                    f"PR **{pr_total}** "
+                    f"(net **{pr_total - base_total:+d}**).\n"
+                )
             f.write("\n<details>\n")
             f.write("<summary>Click here to see details.</summary>\n\n")
 
-            if max_gain + max_loss > MAX_ROWS_IN_MD:
+            total_changes = gains + losses
+            if total_changes > MAX_ROWS_IN_MD:
                 f.write(
-                    f"There were {max_gain + max_loss} changes so we are only "
-                    f"displaying the first 50. You can review the \n"
-                    f"entire list by downloading the output.csv "
-                    f"file linked above.\n\n"
+                    f"There were {total_changes} changes so we are only "
+                    f"displaying the first {MAX_ROWS_IN_MD}. You can review "
+                    f"the\nentire list by downloading the output.csv file "
+                    f"linked above.\n\n"
                 )
-            # Generate Markdown Table of Outputs up to 50 rows.
-            row_count = 0
-            with open("benchmark/output.csv") as inp:
-                reader = csv.DictReader(inp)
+            # Generate Markdown table of outputs, up to MAX_ROWS_IN_MD rows.
+            with open(self.get_filepath("output.csv")) as inp:
                 header = [
                     "id".center(10),
                     "Gain".center(max_gain),
@@ -131,16 +143,15 @@ class Benchmark:
                 f.write(f"| {' | '.join(header)} |\n")
                 blank = ["-" * 10, "-" * max_gain, "-" * max_loss]
                 f.write(f"| {' | '.join(blank)} |\n")
-                for row in reader:
-                    table = []
-                    for value, whitespace_adjust in zip(
-                        list(row.values()), [10, max_gain, max_loss]
-                    ):
-                        table.append(value.center(whitespace_adjust))
-                    f.write(f"| {' | '.join(table)} |\n")
-                    row_count += 1
-                    if row_count > MAX_ROWS_IN_MD:
+                for row_count, row in enumerate(csv.DictReader(inp)):
+                    if row_count >= MAX_ROWS_IN_MD:
                         break
+                    table = [
+                        row["ID"].center(10),
+                        self._md_cell(row["Gain"]).center(max_gain),
+                        self._md_cell(row["Loss"]).center(max_loss),
+                    ]
+                    f.write(f"| {' | '.join(table)} |\n")
 
         with open(self.get_filepath("report.md"), "a+") as f:
             f.write("\n\n</details>\n\n")
@@ -158,11 +169,11 @@ class Benchmark:
             )
             f.write(link)
 
-    def append_links(self, branch1, branch2, pr_number, repo):
+    def append_links(self, base, pr, pr_number, repo):
         """Add links to output in PR document report
 
-        :param branch1: Main branch name
-        :param branch2: Updated branch name
+        :param base: Baseline branch hash (main / original)
+        :param pr: Updated branch hash (the PR)
         :param pr_number: PR # trigger
         :param repo: The repository to upload to
         :return: None
@@ -170,56 +181,78 @@ class Benchmark:
         with open(self.get_filepath("report.md"), "a") as f:
             f.write("\n\nGenerated Files\n---------\n\n")
             f.write(
-                f"[Branch 1 Output](https://raw.githubusercontent.com/"
-                f"{repo}/artifacts/{pr_number}/results/{branch1}.json)\n"
+                f"[Base (main) Output](https://raw.githubusercontent.com/"
+                f"{repo}/artifacts/{pr_number}/results/{base}.json)\n"
             )
             f.write(
-                f"[Branch 2 Output](https://raw.githubusercontent.com/"
-                f"{repo}/artifacts/{pr_number}/results/{branch2}.json)\n"
+                f"[PR Output](https://raw.githubusercontent.com/"
+                f"{repo}/artifacts/{pr_number}/results/{pr}.json)\n"
             )
             f.write(
                 f"[Full Output CSV ](https://raw.githubusercontent.com/"
                 f"{repo}/artifacts/{pr_number}/results/output.csv)\n"
             )
 
-    def generate_time_chart(self, main: str, branch: str) -> None:
-        """Generate time chart showing speed across branches
+    def generate_time_chart(self, base: str, pr: str) -> None:
+        """Generate the gains/losses CSV and the speed-comparison chart.
+
+        ``base`` is the baseline branch (main / original); ``pr`` is the
+        updated branch. A *gain* is a citation the PR finds that the base
+        did not; a *loss* is one the base found that the PR no longer does.
 
         return: None
         """
 
-        with open(f"benchmark/{main}.json") as f:
-            main_file = json.load(f)
+        with open(self.get_filepath(f"{base}.json")) as f:
+            base_file = json.load(f)
 
-        with open(f"benchmark/{branch}.json") as b:
-            branch_file = json.load(b)
+        with open(self.get_filepath(f"{pr}.json")) as b:
+            pr_file = json.load(b)
 
-        with open("benchmark/output.csv", "w") as csvfile:
+        # Compare documents by id rather than by position. Zipping the two
+        # lists assumed both runs emitted rows in the exact same order and
+        # count; a single skipped/reordered document would have silently
+        # misaligned every later comparison.
+        base_by_id = {row["id"]: row["cites"] for row in base_file}
+        pr_by_id = {row["id"]: row["cites"] for row in pr_file}
+        ordered_ids = list(base_by_id) + [
+            i for i in pr_by_id if i not in base_by_id
+        ]
+
+        gains, losses = 0, 0
+        with open(self.get_filepath("output.csv"), "w") as csvfile:
             writer = csv.writer(csvfile)
             writer.writerow(["ID", "Gain", "Loss"])
 
-            for main_row, branch_row in zip(main_file, branch_file):
-                if set(main_row["cites"]) == set(branch_row["cites"]):
+            for doc_id in ordered_ids:
+                base_cites = set(base_by_id.get(doc_id, []))
+                pr_cites = set(pr_by_id.get(doc_id, []))
+                if base_cites == pr_cites:
                     continue
+                for change in sorted(pr_cites - base_cites):
+                    writer.writerow([doc_id, change, ""])
+                    gains += 1
+                for change in sorted(base_cites - pr_cites):
+                    writer.writerow([doc_id, "", change])
+                    losses += 1
 
-                changes = set(main_row["cites"]) ^ set(branch_row["cites"])
-                for change in list(changes):
-                    gain, loss = "", ""
-                    if change in main_row["cites"]:
-                        loss = change
-                    else:
-                        gain = change
-                    writer.writerow([main_row["id"], gain, loss])
+        # Stash summary stats for write_report().
+        self.stats = {
+            "gains": gains,
+            "losses": losses,
+            "base_total": sum(len(c) for c in base_by_id.values()),
+            "pr_total": sum(len(c) for c in pr_by_id.values()),
+        }
 
         plt.plot(
-            [x["time"] for x in main_file],
-            [x["total"] for x in main_file],
-            label=f"Main/{main}",
+            [x["time"] for x in base_file],
+            [x["total"] for x in base_file],
+            label=f"base/{base}",
         )
         plt.plot(
-            [x["time"] for x in branch_file],
-            [x["total"] for x in branch_file],
-            label=branch,
+            [x["time"] for x in pr_file],
+            [x["total"] for x in pr_file],
+            label=f"pr/{pr}",
         )
         plt.legend(loc="upper left")
         plt.ylabel("# Cites Found ", rotation="vertical")
@@ -232,6 +265,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--pr")
     parser.add_argument("--branches", nargs="+")
+    parser.add_argument(
+        "--base",
+        help=(
+            "Hash of the baseline (main) branch, used to orient gains vs. "
+            "losses. Must be one of the two --branches values. Defaults to "
+            "the first branch, so callers that already pass [base, pr] keep "
+            "working."
+        ),
+    )
     parser.add_argument("--reporters", action="store_true")
 
     args = parser.parse_args()
@@ -244,9 +286,14 @@ if __name__ == "__main__":
     if len(args.branches) == 1:
         benchmark.generate_branch_report(branch=args.branches[0])
     elif len(args.branches) == 2:
+        # The second branch is the one checked out during this (second) run,
+        # so it is the one whose report we (re)generate here.
         benchmark.generate_branch_report(branch=args.branches[1])
-        benchmark.generate_time_chart(args.branches[0], args.branches[1])
+        # Orient the diff explicitly: whichever hash is the baseline is the
+        # "base"; the other is the PR. This is needed because the eyecite and
+        # reporters-db workflows pass the two branches in opposite order.
+        base = args.base if args.base in args.branches else args.branches[0]
+        pr = next((b for b in args.branches if b != base), base)
+        benchmark.generate_time_chart(base, pr)
         benchmark.write_report(repo=repo, pr_number=args.pr)
-        benchmark.append_links(
-            args.branches[0], args.branches[1], args.pr, repo
-        )
+        benchmark.append_links(base, pr, args.pr, repo)


### PR DESCRIPTION
Fixes the benchmark report bugs surfaced while reviewing #307. Refs #212.

## Problems

1. **Gains and Losses were inverted on every eyecite PR.** The diff logic assumes `--branches[0]` is the baseline, but the eyecite workflow passes `--branches <PR> <main>` (PR first), while the reporters-db workflow passes `--branches original update` (base first). So one path was always backwards. On #307 the report read "6 gains and 238 losses" when it was actually **238 gains / 6 losses**.
2. **The Markdown table broke** whenever a citation token contained an embedded newline (e.g. `163 Ohio\nSt.3d 242`) — a blank line inside a table ends it on GitHub, so rows silently disappeared.
3. **Documents were compared by `zip` position**, so a single skipped/reordered document would misalign every later comparison.
4. The "only displaying the first 50" notice keyed off **column widths**, not the change count, and was off-by-one.

## Changes

- Orient gains/losses with an explicit `--base` flag. It defaults to the first branch, so the reporters-db ordering keeps working; the eyecite workflow now passes `--base <main>`.
- Sanitize Markdown table cells: collapse whitespace runs (embedded newlines included) and escape pipes. The CSV artifact keeps the raw token text.
- Compare documents by `id` (union of both runs) instead of by position.
- Truncation notice uses the real change count and emits exactly `MAX_ROWS_IN_MD` rows.
- Add a net citation-count summary (base vs PR, with delta).
- Clearer base/PR labels; migrate deprecated `::set-output` → `$GITHUB_OUTPUT`.

## Verification

Exercised `generate_time_chart` + `write_report` with synthetic base/PR JSONs:
- correct gain/loss direction;
- ids present on only one side handled (which `zip` would mispair);
- embedded-newline + pipe cells render cleanly while the CSV stays raw;
- `--base` orientation correct for both workflow argument orders + the no-`--base` default;
- truncation message shows the true count with exactly 50 rows.

YAML parses; `ruff check`/`format` clean; existing test suite passes.

## Deferred (follow-ups, noted on #212)

Per-doc timing statistics, citation type/overlap in the JSON, Hyperscan-path benchmarking, and multiset counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)