### PR TITLE
fix: de-duplicate identical editions in all_editions (#317)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,12 @@ Changes:
 - CI: bump GitHub Actions to Node 24 runtimes, clearing the directly-fixable Node 20 deprecation warnings
 
 Fixes:
--
+- De-duplicate identical editions in `all_editions` (and across
+  `exact_editions`/`variation_editions`) so a single canonical citation never
+  lists the same `Edition` twice. The whitespace relaxation in #305 made every
+  reporter with a whitespace-only variation surface a spurious duplicate, and
+  the `S.W.2d` custom regex did so even before #305; distinct editions
+  (genuine ambiguity) are preserved. #317
 
 ## Current
 

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -59,6 +59,28 @@ class Edition:
         )
 
 
+def _dedupe_editions(
+    exact: Sequence["Edition"], variation: Sequence["Edition"]
+) -> tuple[tuple["Edition", ...], tuple["Edition", ...]]:
+    """De-duplicate editions while preserving order and genuine ambiguity.
+
+    A single ``Edition`` can be reached both as an exact match and as a
+    variation -- e.g. for reporters with whitespace-only variations that the
+    relaxation in #305 makes redundant, or for the ``S.W.2d`` custom regex that
+    omits ``$edition`` so its canonical and variation forms are identical. That
+    surfaces the same object twice in ``all_editions`` (a spurious duplicate,
+    not genuine ambiguity). Dedupe each list, and drop variation editions that
+    are already exact matches, so distinct editions are preserved but a single
+    edition is never listed more than once.
+    """
+    exact = tuple(dict.fromkeys(exact))
+    seen = set(exact)
+    variation = tuple(
+        e for e in dict.fromkeys(variation) if e not in seen
+    )
+    return exact, variation
+
+
 @dataclass(eq=False, unsafe_hash=False)
 class CitationBase:
     """Base class for objects returned by `eyecite.find.get_citations`. We
@@ -255,11 +277,10 @@ class ResourceCitation(CitationBase):
 
     def __post_init__(self):
         """Make iterables into tuples to make sure we're hashable."""
-        self.exact_editions = tuple(self.exact_editions)
-        self.variation_editions = tuple(self.variation_editions)
-        self.all_editions = tuple(self.exact_editions) + tuple(
-            self.variation_editions
+        self.exact_editions, self.variation_editions = _dedupe_editions(
+            self.exact_editions, self.variation_editions
         )
+        self.all_editions = self.exact_editions + self.variation_editions
         super().__post_init__()
 
     def __hash__(self) -> int:
@@ -755,8 +776,9 @@ class CitationToken(Token):
 
     def __post_init__(self):
         """Make iterables into tuples to make sure we're hashable."""
-        self.exact_editions = tuple(self.exact_editions)
-        self.variation_editions = tuple(self.variation_editions)
+        self.exact_editions, self.variation_editions = _dedupe_editions(
+            self.exact_editions, self.variation_editions
+        )
 
     def merge(self, other: "Token") -> Optional["Token"]:
         """To merge citation tokens, also make sure `short` matches,
@@ -765,15 +787,17 @@ class CitationToken(Token):
         if merged:
             other = cast(CitationToken, other)
             if self.short == other.short:
-                self.exact_editions = cast(tuple, self.exact_editions) + cast(
-                    tuple, other.exact_editions
+                # Combine and de-duplicate editions after merge, dropping
+                # variation editions that are also exact matches (see
+                # _dedupe_editions).
+                self.exact_editions, self.variation_editions = (
+                    _dedupe_editions(
+                        cast(tuple, self.exact_editions)
+                        + cast(tuple, other.exact_editions),
+                        cast(tuple, self.variation_editions)
+                        + cast(tuple, other.variation_editions),
+                    )
                 )
-                self.variation_editions = cast(
-                    tuple, self.variation_editions
-                ) + cast(tuple, other.variation_editions)
-                # Remove duplicate editions after merge
-                self.exact_editions = tuple(set(self.exact_editions))
-                self.variation_editions = tuple(set(self.variation_editions))
                 return self
         return None
 

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -75,9 +75,7 @@ def _dedupe_editions(
     """
     exact = tuple(dict.fromkeys(exact))
     seen = set(exact)
-    variation = tuple(
-        e for e in dict.fromkeys(variation) if e not in seen
-    )
+    variation = tuple(e for e in dict.fromkeys(variation) if e not in seen)
     return exact, variation
 
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -905,6 +905,48 @@ class FindTest(TestCase):
         # fmt: on
         self.run_test_pairs(test_pairs, "Relaxed reporter whitespace")
 
+    def test_no_duplicate_editions(self):
+        """Is the same Edition never listed twice in all_editions? (#317)
+
+        A single edition can be reached both as an exact match and as a
+        variation, surfacing the identical Edition object twice. This happens
+        via two independent mechanisms:
+
+        * the whitespace relaxation (#305) makes a reporter's canonical regex
+          and its whitespace-only variation regex both match the plain text
+          (e.g. ``F.3d`` / ``F. 3d``); and
+        * the ``S.W.2d`` custom regex omits ``$edition``, so its canonical and
+          variation substitutions are byte-identical and collapse into one
+          extractor carrying the edition as both an exact match and a variation
+          (this one predates #305).
+
+        Either way the duplicate is a spurious copy of the same edition, not
+        genuine ambiguity, so it must not inflate ``all_editions``.
+        """
+        # Each of these should resolve to exactly one edition, listed once.
+        for cite_string in (
+            "238 F.3d 273",  # whitespace-only variation (#305)
+            "410 U.S. 113",
+            "123 F.2d 456",
+            "5 Cal. 4th 1",
+            "410 S.W.2d 1",  # custom-regex collapse, predates #305
+        ):
+            cite = get_citations(cite_string)[0]
+            self.assertEqual(
+                len(cite.all_editions),
+                1,
+                msg=f"{cite_string!r} has duplicate editions: "
+                f"{[e.short_name for e in cite.all_editions]}",
+            )
+            self.assertEqual(len(set(cite.all_editions)), 1)
+
+        # Genuine ambiguity must be preserved: "B.R." maps to two distinct
+        # editions (Bankruptcy Reporter and Baltimore City Reports), so
+        # de-duplication must not collapse it to one.
+        ambiguous = get_citations("1 B.R. 1")[0]
+        self.assertEqual(len(ambiguous.all_editions), 2)
+        self.assertEqual(len(set(ambiguous.all_editions)), 2)
+
     def test_find_law_citations(self):
         """Can we find citations from laws.json?"""
         # fmt: off

--- a/tests/test_TokenizeTest.py
+++ b/tests/test_TokenizeTest.py
@@ -24,9 +24,11 @@ class TokenizerTest(TestCase):
             # The spaced form "U. S." is both a registered variation and,
             # since reporter whitespace is now relaxed (#305), an exact match
             # for the canonical "U.S." edition. The two overlapping matches
-            # are merged into a single token.
+            # are merged into a single token; the edition is kept as an exact
+            # match and dropped from the variations to avoid a spurious
+            # duplicate in all_editions (#317).
             exact_editions=(us_reporter,),
-            variation_editions=(us_reporter,),
+            variation_editions=(),
         )
         see_token = StopWordToken("See", 0, 3, "see")
         v_token = StopWordToken("v.", 8, 10, "v")


### PR DESCRIPTION
## What

Fixes #317. `get_citations()` was returning the same `Edition` object twice in `all_editions`, e.g.:

```python
c = get_citations("238 F.3d 273")[0]
len(c.all_editions)                     # 2 (was 1 pre-#305)
len(set(c.all_editions))                # 1  -> identical objects
c.all_editions[0] is c.all_editions[1]  # True
```

## Root cause

The whitespace relaxation from #305 turns each period/space in a reporter regex into `\s*`. For a reporter with a whitespace-only variation like `F. 3d`, the variation regex becomes `F\.\s*\s*3d`, which also matches the zero-space text `F.3d`. So two extractors fire on the same span — the *exact* one and the *variation* one — and both register the **same** `Edition` object (one into `exact_editions`, one into `variation_editions`). `CitationToken.merge` only deduped *within* each list, never across them, so `all_editions = exact + variation` carried the duplicate. The `S.W.2d` custom regex hit the same bug independently (its regex omits `$edition`), predating #305.

## Fix

- New `_dedupe_editions()` helper: order-preservingly dedupes each list and drops any variation edition already present as an exact match.
- Routed `ResourceCitation.__post_init__`, `CitationToken.__post_init__`, and `CitationToken.merge` through it.
- Genuinely distinct editions (real ambiguity) are preserved.

## Impact

Fixes downstream false positives in callers that use `len(citation.all_editions)` to detect reporter ambiguity (e.g. CourtListener's `update_casenames_wl_dataset`, which was skipping every whitespace-variation reporter as "unable to disambiguate").

Hash note: this changes the hash of *law and journal* citations that previously carried a duplicate edition. Case citations are unaffected — `CaseCitation.__hash__` never depended on `all_editions`. Resolution grouping within a run is unchanged; only absolute hash values (never persisted) differ across versions.

## Tests

- New `test_no_duplicate_editions` — covers `F.3d`, `U.S.`, the `S.W.2d` collapse, and `B.R.` (genuine ambiguity must survive dedup).
- Updated `test_reporter_tokenizer` assertion.
- Full suite: 54 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)