### PR TITLE
version bump v2.7.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,19 @@ Features:
 -
 
 Changes:
+-
+
+Fixes:
+-
+
+## Current
+
+**2.7.8 - 2026-07-01**
+
+Features:
+-
+
+Changes:
 - CI: bump GitHub Actions to Node 24 runtimes, clearing the directly-fixable Node 20 deprecation warnings
 
 Fixes:
@@ -17,8 +30,6 @@ Fixes:
   reporter with a whitespace-only variation surface a spurious duplicate, and
   the `S.W.2d` custom regex did so even before #305; distinct editions
   (genuine ambiguity) are preserved. #317
-
-## Current
 
 **2.7.7 - 2026-06-25**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "eyecite"
-version = "2.7.7"
+version = "2.7.8"
 description = "Tool for extracting legal citations from text strings."
 readme = "README.rst"
 keywords = ["legal", "courts", "citations", "extraction", "cites"]

--- a/uv.lock
+++ b/uv.lock
@@ -72,7 +72,7 @@ wheels = [
 
 [[package]]
 name = "eyecite"
-version = "2.7.7"
+version = "2.7.8"
 source = { editable = "." }
 dependencies = [
     { name = "courts-db" },


### PR DESCRIPTION
Patch release **2.7.8**.

Rolls the code-complete items from *Upcoming* into a dated *Current* section and bumps the version in `pyproject.toml` / `uv.lock`.

Included since 2.7.7:
- CI: bump GitHub Actions to Node 24 runtimes (#318)
- De-duplicate identical editions in `all_editions` (#317)

Once merged, tag `v2.7.8` on the merge commit to trigger the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)