### PR TITLE
Fix get_citations(markup_text=...) crashing without an "html" clean step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
 -
 
 Fixes:
-- Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when 
+- Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when
   `clean_steps` was omitted or lacked `"html"`. The documented fallback that
   prepends the `html` step was both unreachable and broken.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,9 @@ Changes:
 -
 
 Fixes:
--
+- Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when 
+  `clean_steps` was omitted or lacked `"html"`. The documented fallback that
+  prepends the `html` step was both unreachable and broken.
 
 ## Current
 

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -930,11 +930,13 @@ class Document:
         elif self.markup_text and not self.plain_text:
             self.source_text = self.markup_text
 
-            if "html" not in self.clean_steps:
-                self.clean_steps.insert("html", 0)
+            clean_steps = list(self.clean_steps or [])
+            if "html" not in clean_steps:
+                clean_steps.insert(0, "html")
                 logger.warning(
                     "`html` has been added to `markup_text` clean_steps list"
                 )
+            self.clean_steps = clean_steps
 
             self.plain_text = clean_text(self.markup_text, self.clean_steps)
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -1406,6 +1406,33 @@ class FindTest(TestCase):
                 any(isinstance(cite, ReferenceCitation) for cite in citations)
             )
 
+    def test_markup_text_without_html_clean_step(self) -> None:
+        """Does passing `markup_text` without an `html` clean step auto-add
+        it (with a warning) instead of crashing?
+
+        """
+        markup = "<p>Lissner v. Test, <i>1 U.S. 1</i> (1982)</p>"
+
+        # clean_steps omitted entirely (get_citations defaults it to None)
+        with self.assertLogs("eyecite.models", level="WARNING") as logs:
+            cites = get_citations(markup_text=markup)
+        self.assertEqual([c.matched_text() for c in cites], ["1 U.S. 1"])
+        self.assertTrue(
+            any("`html` has been added" in line for line in logs.output)
+        )
+
+        # clean_steps provided but missing "html", must prepend it
+        with self.assertLogs("eyecite.models", level="WARNING"):
+            cites = get_citations(
+                markup_text=markup, clean_steps=["all_whitespace"]
+            )
+        self.assertEqual([c.matched_text() for c in cites], ["1 U.S. 1"])
+
+        # clean_steps already containing "html" stays untouched and quiet
+        with self.assertNoLogs("eyecite.models", level="WARNING"):
+            cites = get_citations(markup_text=markup, clean_steps=["html"])
+        self.assertEqual([c.matched_text() for c in cites], ["1 U.S. 1"])
+
     def test_markup_plaintiff_and_antecedent_guesses(self) -> None:
         # Can we identify full case names in markup text
         test_pairs = (


### PR DESCRIPTION
Calling the documented markup path without `clean_steps` raises `TypeError: argument of type 'NoneType' is not iterable` (`clean_steps` defaults to `None`), **and** passing a list without `"html"` raises `TypeError: 'str' object cannot be interpreted as an integer`, because `Document.__post_init__` calls `list.insert()` with its arguments reversed:

```
get_citations(markup_text="<p><i>1 U.S. 1</i></p>")   # -> TypeError
get_citations(markup_text="<p><i>1 U.S. 1</i></p>", clean_steps=["all_whitespace"])  #  -> TypeError
```

The intended fallback (prepend "html" and log a warning) was unreachable. This normalizes `clean_steps` to a list and prepends with the correct argument order, so the fallback now works as designed. No behavior change for callers that already pass "html".

Adds a regression test covering all three cases (omitted, missing "html", already present) and a `CHANGES.md` entry.
