### PR TITLE
fix(regexes): parse law edition/supplement parentheticals and widen publisher token

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,15 @@ Changes:
 -
 
 Fixes:
--
+- Parse official U.S. Code edition and supplement parentheticals, and broaden
+  the law-citation publisher token. `POST_LAW_CITATION_REGEX` now extracts
+  `year` from `(2018 ed.)`, `(Supp. II 1997)`, `(1994 ed. & Supp. IV 1998)` and
+  `(West 1994 & Supp. 1997)`, where previously the whole parenthetical was
+  either misfiled as a `parenthetical` or dropped entirely. The publisher token
+  now accepts internal capitals and apostrophes, so `(LexisNexis 2018)` and
+  `(Vernon's 2003)` are captured as publishers. Where a citation carries both a
+  main edition and a supplement year, `year` holds the main edition year.
+  Multi-word publishers such as `(West Group 2000)` are still not matched. #325
 
 ## Current
 

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -357,6 +357,10 @@ POST_SHORT_CITATION_REGEX = rf"""
 """
 
 
+# Roman numeral numbering an official U.S. Code supplement, like "Supp. II".
+# Optional because the shorthand "Supp. 1997" also occurs.
+LAW_SUPPLEMENT_NUMBER_REGEX = r"(?:[IVXL]+\ )?"
+
 # Post law citation regex:
 # statutory and regulatory cites may have publishers and dates after them, like
 #  (West), (West 1999), (Lexis Jun. 2018), (1999), or (May 2, 1999),
@@ -365,9 +369,11 @@ POST_LAW_CITATION_REGEX = rf"""
     {LAW_PIN_CITE_REGEX}?
     \ ?
     (?:\(
-        # Consol., McKinney, Deering, West, LexisNexis, etc.
+        # Consol., McKinney, Deering, West, LexisNexis, Vernon's, etc.
+        # Internal capitals and apostrophes allowed; single word only --
+        # a trailing word would swallow the month in "(West Jan. 1, 2012)".
         (?P<publisher>
-            [A-Z][a-z]+\.?
+            [A-Z][A-Za-z'’]+\.?
             (?:\ Supp\.)?
         )?
         \ ?
@@ -375,8 +381,15 @@ POST_LAW_CITATION_REGEX = rf"""
         (?:{MONTH_REGEX}\ )?
         # day
         (?P<day>\d{{1,2}})?,?\ ?
+        # leading supplement, like "Supp. II 1997"
+        (?:Supp\.\ {LAW_SUPPLEMENT_NUMBER_REGEX})?
         # four-digit year
         {YEAR_REGEX}?
+        # main edition marker, like "2018 ed."
+        (?:\ ed\.)?
+        # trailing supplement, like "& Supp. IV 1998". Its year is matched
+        # but not captured; `year` holds the main edition year.
+        (?:\ &\ Supp\.\ {LAW_SUPPLEMENT_NUMBER_REGEX}\d{{4}})?
     \))?
     \ ?
     # parenthetical

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -358,7 +358,7 @@ POST_SHORT_CITATION_REGEX = rf"""
 
 
 # Roman numeral numbering an official U.S. Code supplement, like "Supp. II".
-# Optional because the shorthand "Supp. 1997" also occurs.
+# Optional for the trailing form, where "& Supp. 1997" occurs.
 LAW_SUPPLEMENT_NUMBER_REGEX = r"(?:[IVXL]+\ )?"
 
 # Post law citation regex:

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -1015,6 +1015,47 @@ class FindTest(TestCase):
              [law_citation('Mass. Gen. Laws ch. 1, §§ 2-3',
                            reporter='Mass. Gen. Laws',
                            groups={'chapter': '1', 'section': '2-3'})]),
+            # Official main edition marker, like "(2018 ed.)" #325
+            ('18 U.S.C. § 1 (2018 ed.)',
+             [law_citation('18 U.S.C. § 1 (2018 ed.)',
+                           reporter='U.S.C.',
+                           groups={'title': '18', 'section': '1'},
+                           year=2018)]),
+            # Official supplement preceding the year #325
+            ('8 U.S.C. § 1101 (Supp. IV 1998)',
+             [law_citation('8 U.S.C. § 1101 (Supp. IV 1998)',
+                           reporter='U.S.C.',
+                           groups={'title': '8', 'section': '1101'},
+                           year=1998)]),
+            # Combined main edition and supplement; `year` is the main
+            # edition year #325
+            ('8 U.S.C. § 1101 (1994 ed. & Supp. IV 1998)',
+             [law_citation('8 U.S.C. § 1101 (1994 ed. & Supp. IV 1998)',
+                           reporter='U.S.C.',
+                           groups={'title': '8', 'section': '1101'},
+                           year=1994)]),
+            # Publisher plus trailing supplement #325
+            ('18 U.S.C. § 1 (West 1994 & Supp. 1997)',
+             [law_citation('18 U.S.C. § 1 (West 1994 & Supp. 1997)',
+                           reporter='U.S.C.',
+                           metadata={'publisher': 'West'},
+                           groups={'title': '18', 'section': '1'},
+                           year=1994)]),
+            # Publisher with an internal capital #325
+            ('18 U.S.C.S. § 1101 (LexisNexis 2018)',
+             [law_citation('18 U.S.C.S. § 1101 (LexisNexis 2018)',
+                           reporter='U.S.C.S.',
+                           metadata={'publisher': 'LexisNexis'},
+                           groups={'title': '18', 'section': '1101'},
+                           year=2018)]),
+            # Publisher with an apostrophe, state code #325
+            ("Tex. Penal Code Ann. § 22.01 (Vernon's 2003)",
+             [law_citation("Tex. Penal Code Ann. § 22.01 (Vernon's 2003)",
+                           reporter='Tex. Code Ann.',
+                           reporter_found='Tex. Penal Code Ann.',
+                           metadata={'publisher': "Vernon's"},
+                           groups={'subject': 'Penal', 'section': '22.01'},
+                           year=2003)]),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Law citation extraction")


### PR DESCRIPTION
## What

Fixes #325. `POST_LAW_CITATION_REGEX` dropped or misfiled most publisher/edition
parentheticals on law citations:

```python
get_citations("18 U.S.C.S. § 1101 (LexisNexis 2018)")[0].metadata
# publisher=None  year=None  parenthetical='LexisNexis 2018'   -> misfiled as prose

get_citations("18 U.S.C. § 1 (2018 ed.)")[0].metadata
# publisher=None  year=None  parenthetical=None                -> lost entirely
```

## Root cause

The publisher/date parenthetical is handled by a single group in
`POST_LAW_CITATION_REGEX`, and every component inside that group is optional.
So when it cannot match the text it does not fail — it matches *empty*, and the
trailing `PARENTHETICAL_REGEX` (`.*`) then consumes the whole parenthetical as
prose commentary. Nothing raises; the metadata is just silently wrong.

Two things it cannot match:

1. **Edition vocabulary.** There is no branch for `ed.`, for a leading `Supp.`
   + roman numeral, or for the combined `X ed. & Supp. Y` form.
2. **Publisher names that are not one plain capitalised word.** `[A-Z][a-z]+`
   is a capital followed by lowercase letters only, so it stops at the second
   capital in `LexisNexis` and at the apostrophe in `Vernon's`.

The `ed.` forms then hit a second step. `process_parenthetical()` discards any
parenthetical beginning with a four-digit year, treating it as a bare year
parenthetical — so `(2018 ed.)` and `(1994 ed. & Supp. IV 1998)` were not
merely misfiled into `parenthetical`, they were dropped entirely.

## Fix

`eyecite/regexes.py` only — three optional branches and one widened class:

- Leading supplement before the year, for `(Supp. II 1997)`.
- Main edition marker `(?:\ ed\.)?` after it, for `(2018 ed.)`.
- Trailing supplement, for `(1994 ed. & Supp. IV 1998)` and
  `(West 1994 & Supp. 1997)`.
- Publisher `[A-Z][a-z]+` → `[A-Z][A-Za-z'’]+` — internal capitals and
  apostrophes, two-character minimum kept. The roman numeral is factored out as
  `LAW_SUPPLEMENT_NUMBER_REGEX`.

Now parsed:

| parenthetical | extracted |
|---|---|
| `(2018 ed.)` | `year='2018'` |
| `(Supp. II 1997)` | `year='1997'` |
| `(1994 ed. & Supp. IV 1998)` | `year='1994'` |
| `(West 1994 & Supp. 1997)` | `publisher='West'`, `year='1994'` |
| `(LexisNexis 2018)` | `publisher='LexisNexis'`, `year='2018'` |
| `(McKinney 2019)` | `publisher='McKinney'`, `year='2019'` |
| `(Vernon's 2003)` | `publisher="Vernon's"`, `year='2003'` |

The last two are the state cases listed as "must not regress" — they fall out
of the shared publisher token.

## Scope

- `year` holds the **main edition** year; the supplement year is matched but
  not captured, since there is one `year` field.
- **No new metadata field** for the edition designation (the issue's
  "ideally") — it would also need `corrected_citation_full()`, which rebuilds
  the cite from `(publisher, month, day, year)`. Happy to add as a follow-up.
- **#326 untouched** — `(May 2, 1999)` still yields `publisher='May'`; fixing it
  means reordering publisher vs month. Verified identical before/after.
- **Multi-word publishers still unmatched.** `(West Group 2000)` falls through
  as before: a trailing word would let the publisher swallow the month in
  `(West Jan. 1, 2012)`.
- **`(Supp. V 1999)` still yields no year**, and this one cannot be fixed in
  the regex. `'v'` is in `STOP_WORDS`, so the tokenizer emits a
  `StopWordToken` inside the parenthetical, and `add_law_metadata` scans with
  `match_on_tokens(..., strings_only=True)`, which stops at the first
  non-string token — the year is never in the text the regex receives. The
  regex does match the form in isolation:

  ```python
  re.search(rf"^(?:{POST_LAW_CITATION_REGEX})", " (Supp. V 1999)", flags=re.X)
  # -> {'year': '1999'}
  ```

  `Supp. I/II/III/IV/VI/X` are unaffected — `V` is the only supplement number
  that collides with a stop word. Worth flagging since it is the second most
  common form in the issue's counts (345 opinions). A fix belongs in
  tokenization, so I have left it out here; happy to open a separate issue.

## Tests

- Six new pairs in `test_find_law_citations`, across all three tokenizers. No
  `McKinney` case — `N.Y. <subject> Law` extracts different groups per
  tokenizer on `main`, unrelated to this regex; `LexisNexis` covers the
  internal-capital path.
- Re-checked `(West 2009)`, `(West Jan. 1, 2012)`, `(Lexis Supp. 2010)`,
  `(2007)`, `(2005-06)`, and `(repealed)` still reaching `parenthetical`.
- Full suite: 54 tests pass. `ruff` check and format clean.
