### PR TITLE
fix(ci): run the benchmark on fork and Dependabot PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,8 +36,19 @@ jobs:
     # `author_association` reports contribution history rather than access --
     # Dependabot reports CONTRIBUTOR -- so the head-repo check is what keeps
     # everyone with write access running automatically. #332
+    #
+    # The `labeled` clause keeps an unrelated label from re-running the
+    # benchmark: `labeled` fires for every label, so on a PR that already
+    # passes the gate below, adding `bug` triggered a full re-run -- and with
+    # `cancel-in-progress` that cancels the in-flight benchmark rather than
+    # merely duplicating it. It has to be `action != 'labeled' || ...` rather
+    # than a plain equality, because `github.event.label` is absent on
+    # opened/synchronize/reopened; comparing it there would be false and the
+    # benchmark would only ever run on labeling.
     if: >-
       github.event_name == 'pull_request'
+      && (github.event.action != 'labeled'
+      || github.event.label.name == 'run-benchmark')
       && (github.event.pull_request.head.repo.full_name == github.repository
       || github.event.pull_request.author_association == 'MEMBER'
       || github.event.pull_request.author_association == 'OWNER'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,17 +1,51 @@
 name: Benchmark Pull Request
 on:
   pull_request:
+    # `labeled` lets a maintainer opt a fork PR in (see the `if:` below). Once
+    # `types:` is set the defaults no longer apply, so they must be listed.
+    types: [opened, synchronize, reopened, labeled]
   repository_dispatch:
     types: [ reporters-db-pr ]
 
 env:
   main: "$(/usr/bin/git log -1 --format='%H')"
 
+# A new push supersedes any benchmark still running for the same PR, so only
+# the newest commit is measured. Keyed on the PR number rather than
+# `github.head_ref` (as tests.yml uses) because two forks can share a branch
+# name -- `patch-1` is GitHub's default for web edits -- and would otherwise
+# cancel each other. `repository_dispatch` runs have no PR number and fall
+# back to a unique run id, so they never cancel one another.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+# This workflow runs the PR's own code, so it must never hold a writable
+# token: for fork PRs GitHub already forces one that is read-only, and we
+# declare it here so the same is true for internal branches. Commenting and
+# pushing results happen in publish-benchmark.yml, which never runs PR code.
+permissions:
+  contents: read
+
 jobs:
   benchmark:
-    name: PR comment
-    if: github.event_name == 'pull_request'
+    name: Benchmark
+    # Run automatically for anything pushed to this repo (all maintainers, plus
+    # Dependabot) and for org members working from a personal fork. Other fork
+    # PRs need a maintainer to add the `run-benchmark` label. Note that
+    # `author_association` reports contribution history rather than access --
+    # Dependabot reports CONTRIBUTOR -- so the head-repo check is what keeps
+    # everyone with write access running automatically. #332
+    if: >-
+      github.event_name == 'pull_request'
+      && (github.event.pull_request.head.repo.full_name == github.repository
+      || github.event.pull_request.author_association == 'MEMBER'
+      || github.event.pull_request.author_association == 'OWNER'
+      || contains(github.event.pull_request.labels.*.name, 'run-benchmark'))
     runs-on: ubuntu-latest
+    # Runs have never exceeded 4m; this caps a hung or hostile one well short
+    # of the 6 hour default while leaving room for a slow runner.
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -27,17 +61,6 @@ jobs:
         with:
           enable-cache: true
           version: "0.7.x"
-
-      - name: Add or Update comment on PR that Test is running
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          recreate: true
-          message: |
-            Eyecite Benchmarking in progress...
-
-            For details, see: https://github.com/freelawproject/eyecite/actions/workflows/benchmark.yml
-
-            This message will be updated when the test is completed.
 
       - name: Install Python dependencies
         run: |
@@ -123,31 +146,31 @@ jobs:
           mv benchmark/output.csv benchmark/${{ steps.branch1.outputs.hash }}.json benchmark/${{ steps.branch2.outputs.hash }}.json benchmark/report.md benchmark/chart.png results/
 
       #----------------------------------------------
-      #             Upload to Github PR
+      #             Hand off to publish-benchmark.yml
+      #
+      # We cannot comment or push from here: this job has a read-only token by
+      # design. Upload the results instead; publish-benchmark.yml picks them up
+      # on `workflow_run` and does the privileged half.
+      #
+      # The PR number travels inside the artifact because
+      # `github.event.workflow_run.pull_requests` is empty for fork PRs.
       #----------------------------------------------
-      - name: Pushes test file
-        uses: dmnemec/copy_file_to_another_repo_action@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.FREELAWBOT_TOKEN }}
-        with:
-          user_email: 'info@free.law'
-          user_name: 'freelawbot'
-          source_file: 'results/'
-          destination_repo: 'freelawproject/eyecite'
-          destination_folder: '${{ github.event.number }}'
-          destination_branch: 'artifacts'
-          commit_message: 'feat(ci): Add artifacts for PR# ${{ github.event.number }}'
+      - name: Record PR number for the publish workflow
+        run: echo "${{ github.event.number }}" > results/pr-number.txt
 
-      - name: Add or Update PR Comment from Generated Report
-        uses: marocchino/sticky-pull-request-comment@v3
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
         with:
-          recreate: true
-          path: results/report.md
+          name: benchmark-results
+          path: results/
+          retention-days: 7
+          if-no-files-found: error
 
   dispatch:
     name: Reporters-DB-Dipatch
     if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -195,7 +218,10 @@ jobs:
           mv benchmark/output.csv benchmark/original.json benchmark/update.json benchmark/report.md benchmark/chart.png results/
 
       - name: Pushes test file
-        uses: dmnemec/copy_file_to_another_repo_action@main
+        # Pinned to a commit: `@main` is a mutable ref, and this is the step
+        # that receives FREELAWBOT_TOKEN. The SHA below is what `main` has
+        # resolved to since 2022-02-04, so this changes nothing behaviourally.
+        uses: dmnemec/copy_file_to_another_repo_action@bbebd3da22e4a37d04dca5f782edd5201cb97083 # main @ 2022-02-04
         env:
           API_TOKEN_GITHUB: ${{ secrets.FREELAWBOT_TOKEN }}
         with:

--- a/.github/workflows/publish-benchmark.yml
+++ b/.github/workflows/publish-benchmark.yml
@@ -1,0 +1,128 @@
+name: Publish Benchmark Results
+
+# The privileged half of the benchmark (#332). benchmark.yml runs the PR's own
+# code and therefore only ever holds a read-only token, which is why it cannot
+# comment on the PR or push to the artifacts branch itself. `workflow_run`
+# fires once it finishes and always executes *this* file as it exists on the
+# default branch, with a normal write token and access to secrets.
+#
+# The safety property this rests on: nothing here checks out or executes any
+# code from the pull request. This job only ever handles the data files the
+# other workflow produced. Keep it that way.
+on:
+  workflow_run:
+    workflows: ["Benchmark Pull Request"]
+    types: [completed]
+
+# Every run of this workflow pushes to the same `artifacts` branch, so two
+# PRs finishing at once would race and one push would lose. A single global
+# group serialises them. `cancel-in-progress: false` because both sets of
+# results should land -- we want to queue here, not drop.
+concurrency:
+  group: publish-benchmark-artifacts
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read           # to download the artifact from the triggering run
+  pull-requests: write    # to post the sticky comment
+
+jobs:
+  publish:
+    name: Publish benchmark report
+    # Skip the reporters-db `repository_dispatch` runs, which publish
+    # themselves, and skip runs that failed or were gated out by the label
+    # check (a fully skipped run does not conclude as success).
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    # Only downloads an artifact, pushes it, and comments -- well under a
+    # minute in practice.
+    timeout-minutes: 10
+    steps:
+      - name: Download benchmark results
+        uses: actions/download-artifact@v8
+        with:
+          name: benchmark-results
+          path: results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # The artifact was produced by a job running fork code, so everything in
+      # it is untrusted input. Read the PR number without ever letting its
+      # contents reach the shell, then confirm with the API that the PR really
+      # is the one that produced this run -- otherwise a fork could point us at
+      # someone else's PR and have us comment on it or overwrite its artifacts.
+      - name: Resolve and verify PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          EXPECTED_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          # Bound the read before filtering: piping an unbounded file into a
+          # truncating `head` would SIGPIPE the reader and abort under
+          # pipefail, failing with no diagnostic. Reject anything that is not
+          # plainly a PR number rather than salvaging digits out of it.
+          number=$(head -c 64 results/pr-number.txt | tr -d '[:space:]')
+          if ! printf '%s' "$number" | grep -Eq '^[0-9]{1,9}$'; then
+            echo "::error::artifact contained no usable PR number"
+            exit 1
+          fi
+          actual=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$number" \
+            --jq '"\(.head.repo.full_name):\(.head.ref)"')
+          if [ "$actual" != "$EXPECTED_REPO:$EXPECTED_BRANCH" ]; then
+            echo "::error::PR #$number is $actual, but this run came from $EXPECTED_REPO:$EXPECTED_BRANCH"
+            exit 1
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      # Anything the fork slipped into results/ would otherwise be served from
+      # raw.githubusercontent.com under our org, so publish only what
+      # benchmark.py is expected to produce.
+      - name: Drop unexpected files
+        run: |
+          set -euo pipefail
+          cd results
+          rm -f pr-number.txt
+          # dotglob because a bare `*` skips dotfiles; nullglob so an empty
+          # directory does not leave the literal `*` to be processed.
+          shopt -s dotglob nullglob
+          for f in *; do
+            case "$f" in
+              output.csv|report.md|chart.png|*.json)
+                # Keep only real files: a directory or a symlink wearing an
+                # allowed name should not reach the artifacts branch.
+                if [ -f "$f" ] && [ ! -L "$f" ]; then
+                  continue
+                fi
+                ;;
+            esac
+            echo "::warning::dropping unexpected entry from benchmark artifact: $f"
+            rm -rf -- "$f"
+          done
+
+      - name: Push results to the artifacts branch
+        # Pinned to a commit: `@main` is a mutable ref, and this is the step
+        # that receives FREELAWBOT_TOKEN. The SHA below is what `main` has
+        # resolved to since 2022-02-04, so this changes nothing behaviourally.
+        uses: dmnemec/copy_file_to_another_repo_action@bbebd3da22e4a37d04dca5f782edd5201cb97083 # main @ 2022-02-04
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.FREELAWBOT_TOKEN }}
+        with:
+          user_email: 'info@free.law'
+          user_name: 'freelawbot'
+          source_file: 'results/'
+          destination_repo: 'freelawproject/eyecite'
+          destination_folder: '${{ steps.pr.outputs.number }}'
+          destination_branch: 'artifacts'
+          commit_message: 'feat(ci): Add artifacts for PR# ${{ steps.pr.outputs.number }}'
+
+      - name: Add or update PR comment from generated report
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          recreate: true
+          number: ${{ steps.pr.outputs.number }}
+          path: results/report.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,8 @@ Features:
 -
 
 Changes:
--
+- CI: the benchmark now works on fork and Dependabot PRs, with commenting and artifact pushes split into a separate privileged workflow, and fork PRs gated behind a `run-benchmark` label. #332
+- CI: benchmark runs are superseded when a PR is updated, time out after 15 minutes, and pin their third-party action to a commit SHA. #332
 
 Fixes:
 -


### PR DESCRIPTION
The benchmark job both ran the PR's code and commented on the PR, so it needed a writable token in a context where GitHub only grants a read-only one. It died at its first step for every fork and Dependabot PR -- 66 of the last 81 runs -- and no fork PR has ever produced a benchmark.

Split the privileged half into publish-benchmark.yml, which runs from the default branch on workflow_run and never checks out PR code. benchmark.yml uploads its results as an artifact instead, and holds only `contents: read`.

Fork PRs are gated behind a `run-benchmark` label; anything pushed to this repo (every maintainer, plus Dependabot) still runs automatically. The gate keys on the head repo rather than author_association, which reports contribution history rather than access -- Dependabot reports CONTRIBUTOR.

Also adds concurrency groups so a new push supersedes a running benchmark, 15 minute job timeouts in place of the 6 hour default, and pins copy_file_to_another_repo_action to a commit SHA instead of a mutable ref.

Fixes #332