### PR TITLE
Fix HyperscanTokenizer silently dropping citations near non-ASCII characters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,10 @@ Changes:
 -
 
 Fixes:
--
+- Fix `HyperscanTokenizer` silent dropping citations adjacent to multi-byte
+  characters, either preceding (e.g. the `“` in `“1 U.S. 1”`) or following
+  (e.g. en dash `–` in `1 U.S. 1–2`). Byte offsets that land inside a multi-
+  byte character are now snapped to the next character boundary instead.
 
 ## Current
 

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -539,10 +539,29 @@ class HyperscanTokenizer(Tokenizer):
         # Get all matches, with byte offsets because hyperscan uses
         # bytes instead of unicode:
         text_bytes = text.encode("utf8")
+        text_bytes_len = len(text_bytes)
         matches = []
 
+        # Hyperscan matches bytes, so a pattern can consume part of a
+        # multi-byte character and report an offset inside it. Snap forward
+        # to the next character rather than drop the match; an end offset gains
+        # the whole character, a start offset loses its leading character, but
+        # the ^ in (?:^|[^a-zA-Z0-9]) matches.
+        def snap_to_boundary(offset: int) -> int:
+            """Enforces that the offset is at a UTF-8 character boundary."""
+            while (  # UTF-8 continuation bytes have the form 0b10xxxxxx
+                offset < text_bytes_len and text_bytes[offset] & 0xC0 == 0x80
+            ):
+                offset += 1
+            return offset
+
         def on_match(index, start, end, flags, context):
-            matches.append((self.extractors[index], (start, end)))
+            matches.append(
+                (
+                    self.extractors[index],
+                    (snap_to_boundary(start), snap_to_boundary(end)),
+                )
+            )
 
         self.hyperscan_db.scan(text_bytes, match_event_handler=on_match)
 
@@ -554,27 +573,20 @@ class HyperscanTokenizer(Tokenizer):
         str_offset = 0
         byte_offsets = sorted({i for m in matches for i in m[1]})
         for byte_offset in byte_offsets:
-            try:
-                str_offset += len(
-                    text_bytes[last_byte_offset:byte_offset].decode("utf8")
-                )
-            except UnicodeDecodeError:
-                # offsets will fail to decode for invalid regex matches
-                # that don't align with a unicode character
-                continue
+            str_offset += len(
+                text_bytes[last_byte_offset:byte_offset].decode("utf8")
+            )
             byte_to_str_offset[byte_offset] = str_offset
             last_byte_offset = byte_offset
 
-        # Narrow down our matches to only those that successfully decoded,
         # re-run regex against just the matching strings to get match groups
         # (which aren't provided by hyperscan), and tokenize:
         for extractor, (start, end) in matches:
-            if start in byte_to_str_offset and end in byte_to_str_offset:
-                start = byte_to_str_offset[start]
-                end = byte_to_str_offset[end]
-                m = extractor.compiled_regex.match(text[start:end])
-                if m:
-                    yield extractor.get_token(m, offset=start)
+            start = byte_to_str_offset[start]
+            end = byte_to_str_offset[end]
+            m = extractor.compiled_regex.match(text[start:end])
+            if m:
+                yield extractor.get_token(m, offset=start)
 
     @property
     def hyperscan_db(self):

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -905,6 +905,51 @@ class FindTest(TestCase):
         # fmt: on
         self.run_test_pairs(test_pairs, "Relaxed reporter whitespace")
 
+    def test_citations_adjacent_to_multibyte_characters(self):
+        """Are citations touching multi-byte characters found by every
+        tokenizer?
+
+        Hyperscan matches bytes, so a pattern that consumes only part of a
+        multi-byte character (e.g. a negated character class matching one
+        byte of an en dash) reports an offset inside that character. Such
+        matches used to be dropped instead of snapped to the character
+        boundary, silently losing citations that the other tokenizers find.
+        The ASCII-only fixtures elsewhere in this file cannot catch that, so
+        keep these strings non-ASCII.
+        """
+        # fmt: off
+        test_pairs = (
+            # Curly quote right before the volume. Extractors open with
+            # (?:^|[^a-zA-Z0-9]), so the byte before the volume is part of
+            # the match and lands inside the quote character
+            ('Lissner v. Test, “1 U.S. 1” (1982)',
+             [case_citation(metadata={'plaintiff': 'Lissner',
+                                      'defendant': 'Test',
+                                      'extra': '”'},
+                            year=1982)]),
+            # En dash right after the page number, as in US Reports page
+            # ranges
+            ('Lissner v. Test, 1 U.S. 1–2 (1982)',
+             [case_citation(metadata={'plaintiff': 'Lissner',
+                                      'defendant': 'Test',
+                                      'extra': '–2'},
+                            year=1982)]),
+            # En dash right after a short cite's page. The en dash also
+            # stops pin-cite parsing, so pin_cite stays unset rather than
+            # taking the factory's page default.
+            ('before Foo 1 U. S., at 339–340 after',
+             [case_citation(page='339', reporter_found='U. S.', short=True,
+                            metadata={'antecedent_guess': 'Foo',
+                                      'pin_cite': None})]),
+            # Multi-byte character (§ is two bytes) inside the matched text
+            # itself, not just at its edge
+            ('18 U.S.C. § 4241–4243',
+             [law_citation('18 U.S.C. § 4241–4243', reporter='U.S.C.',
+                           groups={'title': '18', 'section': '4241'})]),
+        )
+        # fmt: on
+        self.run_test_pairs(test_pairs, "Multi-byte adjacent citations")
+
     def test_no_duplicate_editions(self):
         """Is the same Edition never listed twice in all_editions? (#317)
 


### PR DESCRIPTION

## Description
`HyperscanTokenizer` gets byte offsets back from hyperscan and translates them to string offsets before re-running the Python regex. When a pattern consumed only part of a multi-byte character, the reported offset landed inside that character, the translation failed, and the match was discarded with no error or log line.

### Reproduce it

```python
from pathlib import Path

from eyecite import get_citations
from eyecite.tokenizers import AhocorasickTokenizer, HyperscanTokenizer

text = Path("tests/assets/opinion.txt").read_text()

aho = get_citations(text, tokenizer=AhocorasickTokenizer())
hyperscan = get_citations(text, tokenizer=HyperscanTokenizer())
print(f"ahocorasick: {len(aho)}   hyperscan: {len(hyperscan)}")

found = {c.span() for c in hyperscan}
for cite in aho:
    if cite.span() not in found:
        start, end = cite.span()
        print(f"  missed by hyperscan: {text[start:end + 8]!r}")
```

- `ahocorasick` returns **170** citations, `hyperscan` only **163**
- In this opinion file, all dropped examples are all followed by an en dash, e.g. `438 U. S., at 311–312`, but the bug applies to any non-ASCII character.


## Fix

Snap an offset that lands mid character forward to the next character boundary instead of throwing the match away. Snapping happens in the hyperscan match callback, so every offset downstream is boundary aligned by construction.
