### PR TITLE
fix(ci): harden repository_dispatch benchmark job against script injection

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -186,6 +186,21 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
+      - name: Validate dispatch payload
+        # `client_payload` is caller-supplied JSON, and pr_number/commit are
+        # used by every step below (sticky comments, the install URL,
+        # destination_folder), so gate the whole job here. The error output
+        # deliberately omits the raw value: the payload can contain newlines,
+        # and a second echoed line would be parsed by the runner as a
+        # workflow command.
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.pr_number }}
+          COMMIT: ${{ github.event.client_payload.commit }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[0-9]{1,9}$ ]] || { echo "::error::client_payload.pr_number malformed"; exit 1; }
+          [[ "$COMMIT" =~ ^[0-9a-fA-F]{7,40}$ ]] || { echo "::error::client_payload.commit malformed"; exit 1; }
+
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v6
@@ -221,25 +236,14 @@ jobs:
         # the shell as `${{ ... }}` -- that substitutes the raw text before bash
         # parses the line, so a value like `x$(...)` or `` x`...` `` would
         # execute in this job, which holds FREELAWBOT_TOKEN. Pass it through the
-        # environment instead (bash never re-parses an env value) and validate
-        # the shape before either value reaches a command.
+        # environment instead (bash never re-parses an env value); the shape of
+        # both values is checked by the "Validate dispatch payload" step above.
         env:
           PR_NUMBER: ${{ github.event.client_payload.pr_number }}
           COMMIT: ${{ github.event.client_payload.commit }}
         run: |
           set -euo pipefail
-          if ! printf '%s' "$PR_NUMBER" | grep -Eq '^[0-9]{1,9}$'; then
-            echo "::error::client_payload.pr_number is not a plain number: $PR_NUMBER"
-            exit 1
-          fi
-          # A git commit ref: 7-40 hex chars. Rejecting anything else keeps the
-          # value safe to splice into the install URL below.
-          if ! printf '%s' "$COMMIT" | grep -Eiq '^[0-9a-f]{7,40}$'; then
-            echo "::error::client_payload.commit is not a commit sha: $COMMIT"
-            exit 1
-          fi
           uv pip install "git+https://github.com/freelawproject/reporters-db.git"
-          echo "$PR_NUMBER"
           curl https://storage.courtlistener.com/bulk-data/eyecite/tests/one-percent.csv.bz2 --output benchmark/bulk-file.csv.bz2
           python benchmark/benchmark.py --branches original
           uv pip install "git+https://github.com/freelawproject/reporters-db.git@$COMMIT"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -217,14 +217,34 @@ jobs:
           echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
 
       - name: Run Tests
+        # `client_payload` is caller-supplied JSON. Never interpolate it into
+        # the shell as `${{ ... }}` -- that substitutes the raw text before bash
+        # parses the line, so a value like `x$(...)` or `` x`...` `` would
+        # execute in this job, which holds FREELAWBOT_TOKEN. Pass it through the
+        # environment instead (bash never re-parses an env value) and validate
+        # the shape before either value reaches a command.
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.pr_number }}
+          COMMIT: ${{ github.event.client_payload.commit }}
         run: |
+          set -euo pipefail
+          if ! printf '%s' "$PR_NUMBER" | grep -Eq '^[0-9]{1,9}$'; then
+            echo "::error::client_payload.pr_number is not a plain number: $PR_NUMBER"
+            exit 1
+          fi
+          # A git commit ref: 7-40 hex chars. Rejecting anything else keeps the
+          # value safe to splice into the install URL below.
+          if ! printf '%s' "$COMMIT" | grep -Eiq '^[0-9a-f]{7,40}$'; then
+            echo "::error::client_payload.commit is not a commit sha: $COMMIT"
+            exit 1
+          fi
           uv pip install "git+https://github.com/freelawproject/reporters-db.git"
-          echo ${{ github.event.client_payload.pr_number }}
+          echo "$PR_NUMBER"
           curl https://storage.courtlistener.com/bulk-data/eyecite/tests/one-percent.csv.bz2 --output benchmark/bulk-file.csv.bz2
           python benchmark/benchmark.py --branches original
-          uv pip install "git+https://github.com/freelawproject/reporters-db.git@${{ github.event.client_payload.commit }}"
+          uv pip install "git+https://github.com/freelawproject/reporters-db.git@$COMMIT"
           # "original" is the baseline; "update" is the reporters-db PR.
-          python benchmark/benchmark.py --branches original update --base original --reporters --pr ${{ github.event.client_payload.pr_number }}
+          python benchmark/benchmark.py --branches original update --base original --reporters --pr "$PR_NUMBER"
           mkdir results
           mv benchmark/output.csv benchmark/original.json benchmark/update.json benchmark/report.md benchmark/chart.png results/
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Changes:
 - CI: benchmark runs are superseded when a PR is updated, time out after 15 minutes, and pin their third-party action to a commit SHA. #332
 
 Fixes:
+- CI: harden the benchmark's `repository_dispatch` job against shell script
+  injection by passing `client_payload` values through the environment and
+  validating their shape, instead of interpolating them into `run:`. #337
 - Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when
   `clean_steps` was omitted or lacked `"html"`. The documented fallback that
   prepends the `html` step was both unreachable and broken.


### PR DESCRIPTION
## What

The `dispatch` job in `benchmark.yml` (the `repository_dispatch` path used by reporters-db CI) interpolated caller-supplied event data straight into a `run:` shell block:

```yaml
echo ${{ github.event.client_payload.pr_number }}
uv pip install "git+https://github.com/freelawproject/reporters-db.git@${{ github.event.client_payload.commit }}"
python benchmark/benchmark.py ... --pr ${{ github.event.client_payload.pr_number }}
```

`${{ ... }}` substitutes the raw text **before** bash parses the line, so a crafted `commit` value such as `` x`...` `` or `x$(...)` would be executed by the shell. This job holds `FREELAWBOT_TOKEN`, so that is command execution with a write-capable token.

Triggering `repository_dispatch` requires a token with write access, so this is not remotely exploitable by an outside contributor — it's **defense-in-depth** and brings this job in line with the hardening the rest of the benchmark workflow already got in #332. It's also exactly the pattern GitHub's own [script-injection guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) warns against.

## Change

- Route `client_payload.pr_number` and `client_payload.commit` through `env:` (bash never re-parses an env value) and reference them as quoted `"$PR_NUMBER"` / `"$COMMIT"`.
- Validate shape before use: `pr_number` must be 1–9 digits, `commit` must be 7–40 hex chars. A malformed payload fails the step loudly instead of running.
- `set -euo pipefail` for the step.

No behavioural change for a legitimate reporters-db dispatch payload.

## Scope / not included

This is deliberately narrow. Left as follow-ups if wanted:

- The `client_payload.pr_number` interpolations inside `with:` blocks (action inputs, not shell) are not a shell-injection vector and are unchanged.
- The `pull_request` benchmark job and `publish-benchmark.yml` already follow the secure split from #332 and are untouched.

## Testing

`benchmark.yml` parses as valid YAML. The `dispatch` path only runs on a real `repository_dispatch` from reporters-db, so it can't be exercised from this PR; the regex gates are standard POSIX `grep -E`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)