### PR TITLE
fix(tokenizers): relax whitespace at full-cite template boundaries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ Fixes:
 - Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when
   `clean_steps` was omitted or lacked `"html"`. The documented fallback that
   prepends the `html` step was both unreachable and broken.
+- Match "glued" citations (`846F.2d746`) by relaxing whitespace at the
+  full-cite template's volume-reporter and reporter-page boundaries,
+  completing the #305 relaxation; `_relax_ws` now trims its trailing `\s*`
+  so the reporter group never captures boundary whitespace. #338
 
 ## Current
 
@@ -57,7 +61,7 @@ Features:
 
 Changes:
 - Move dependency management to uv.
-  This shouldn’t have any visible impact to users, except from a few small metadata changes.
+  This shouldn't have any visible impact to users, except from a few small metadata changes.
 
 Fixes:
 - Fixes rendering of AhocorasickTokenizer parameter definition in API docs #279

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,13 @@ Fixes:
   full-cite template's volume-reporter and reporter-page boundaries,
   completing the #305 relaxation; `_relax_ws` now trims its trailing `\s*`
   so the reporter group never captures boundary whitespace. #338
+- Match both of two adjacent citations that share a single separator
+  character (`347 U.S. 483,349 U.S. 294` silently lost the second
+  citation): `TokenExtractor.get_matches` resumes scanning at the end of
+  the token content, so a separator consumed as one match's trailing
+  boundary stays available as the next match's leading boundary. This
+  aligns the pure-Python tokenizers with `HyperscanTokenizer`, which
+  reports overlapping matches and never had this blind spot. #338
 
 ## Current
 

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -850,8 +850,25 @@ class TokenExtractor:
     strings: list = field(default_factory=list)
 
     def get_matches(self, text):
-        """Return match objects for all matches in text."""
-        return self.compiled_regex.finditer(text)
+        """Return match objects for all matches in text.
+
+        Successive searches resume from the end of the token content
+        (group 1) rather than the end of the full match: boundary
+        wrappers like nonalphanum_boundaries_re consume one character
+        on each side, so under finditer semantics a separator consumed
+        as one match's trailing boundary is unavailable as the next
+        match's leading boundary, and the second of two adjacent
+        citations is silently skipped (e.g. the parallel cite
+        "347 U.S. 483,349 U.S. 294" loses "349 U.S. 294"). Hyperscan
+        reports overlapping matches, so HyperscanTokenizer does not
+        share this blind spot; resuming at the content boundary keeps
+        the two tokenizers consistent.
+        """
+        pos = 0
+        while m := self.compiled_regex.search(text, pos):
+            yield m
+            end = m.end(1) if m.re.groups and m.end(1) != -1 else m.end()
+            pos = end if end > pos else pos + 1
 
     def get_token(self, m, offset=0) -> Token:
         """For a given match object, return a Token."""

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -117,6 +117,12 @@ def _relax_ws(escaped: str) -> str:
     # (`re.escape` escapes a space as "\ "; match it with or without the
     # backslash so this is robust across Python versions.)
     escaped = re.sub(r"(?:\\?\ )+", r"\\s*", escaped)
+    # Drop a trailing optional-whitespace so the abbreviation pattern never
+    # captures whitespace past its final token: with flexible whitespace at
+    # the template boundaries there is no following literal space to force
+    # the greedy \s* to backtrack, so e.g. `U\.S\.\s*` would capture
+    # "U.S. " (trailing space) into the reporter group.
+    escaped = re.sub(r"(?:\\s\*)+$", "", escaped)
     return escaped
 
 
@@ -135,7 +141,7 @@ def _populate_reporter_extractors():
 
     # Set up regex replacement variables from reporters-db
     raw_regex_variables = deepcopy(RAW_REGEX_VARIABLES)
-    raw_regex_variables["full_cite"][""] = "$volume $reporter,? $page"
+    raw_regex_variables["full_cite"][""] = r"$volume\s*$reporter,?\s*$page"
     raw_regex_variables["page"][""] = rf"(?P<page>{PAGE_NUMBER_REGEX})"
     regex_variables = process_variables(raw_regex_variables)
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -954,6 +954,36 @@ class FindTest(TestCase):
         # fmt: on
         self.run_test_pairs(test_pairs, "Glued citations")
 
+    def test_adjacent_citations_share_boundary(self):
+        """Do two citations separated by a single character both match?
+
+        The nonalphanum boundary wrappers consume one character on each
+        side of a match, so under finditer semantics a separator consumed
+        as one citation's trailing boundary was unavailable as the next
+        citation's leading boundary, and the second citation was silently
+        skipped. Parallel cites hit this whenever the separator is a bare
+        comma with no following space — common in OCR output, where it
+        composes with glued citations ("347U.S. 483,349 U.S. 294"), but
+        also present in born-digital text ("347 U.S. 483,349 U.S. 294"),
+        where the swallow predates the glued-citation relaxation.
+        HyperscanTokenizer reports overlapping matches and never had this
+        blind spot; `TokenExtractor.get_matches` now resumes scanning at
+        the end of the token content so the pure-Python tokenizers agree.
+        """
+        # fmt: off
+        test_pairs = (
+            # Parallel cite, second member glued to the shared comma
+            ('347 U.S. 483,349 U.S. 294',
+             [case_citation(volume='347', page='483'),
+              case_citation(volume='349', page='294')]),
+            # Composes with glue inside the first citation itself
+            ('347U.S. 483,349 U.S. 294',
+             [case_citation(volume='347', page='483'),
+              case_citation(volume='349', page='294')]),
+        )
+        # fmt: on
+        self.run_test_pairs(test_pairs, "Adjacent citations")
+
     def test_no_duplicate_editions(self):
         """Is the same Edition never listed twice in all_editions? (#317)
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -905,6 +905,55 @@ class FindTest(TestCase):
         # fmt: on
         self.run_test_pairs(test_pairs, "Relaxed reporter whitespace")
 
+    def test_glued_citations(self):
+        """Do we match citations with no space at the template boundaries?
+
+        Real-world documents (OCR output, but also born-digital PDF text
+        layers) drop the spaces between volume, reporter, and page:
+        "846F.2d746". The full-cite template relaxes both boundaries to
+        `\\s*`, extending #305's within-reporter relaxation, and `_relax_ws`
+        trims its trailing `\\s*` so the reporter group never captures
+        boundary whitespace. See #338.
+        """
+        # fmt: off
+        test_pairs = (
+            # Glued at both boundaries
+            ('846F.2d746',
+             [case_citation(volume='846', page='746', reporter='F.2d')]),
+            ('410U.S.113',
+             [case_citation(volume='410', page='113')]),
+            # Glued at one boundary only
+            ('846F.2d 746',
+             [case_citation(volume='846', page='746', reporter='F.2d')]),
+            ('846 F.2d746',
+             [case_citation(volume='846', page='746', reporter='F.2d')]),
+            # Boundary glue composes with the #305 within-reporter
+            # relaxation (and the reporter group stays clean of boundary
+            # whitespace on the spaced side)
+            ('799N. Y. S. 2d795',
+             [case_citation(volume='799', page='795',
+                            reporter='N.Y.S.2d',
+                            reporter_found='N. Y. S. 2d')]),
+            # Short cite glued at the volume boundary, through the
+            # separate short_cite_re path
+            ('757F.2d at 1241',
+             [case_citation(volume='757', page='1241', reporter='F.2d',
+                            short=True,
+                            metadata={'pin_cite': '1241'})]),
+            # Case-name and year parsing still work around a glued cite
+            ('Lissner v. Test 846F.2d746 (1988)',
+             [case_citation(volume='846', page='746', reporter='F.2d',
+                            year=1988,
+                            metadata={'plaintiff': 'Lissner',
+                                      'defendant': 'Test'})]),
+            # A valid page token must still follow: street addresses and
+            # document labels with a bare reporter-like token do not match
+            ('7F., No. 106, Sec. 5',
+             []),
+        )
+        # fmt: on
+        self.run_test_pairs(test_pairs, "Glued citations")
+
     def test_no_duplicate_editions(self):
         """Is the same Edition never listed twice in all_editions? (#317)
 


### PR DESCRIPTION
## Fixes

Fixes: #338

## Summary

Glued citations (`846F.2d746`) currently extract as nothing: the full-cite
template requires exactly one literal space at the volume-reporter and
reporter-page boundaries. This extends #305's whitespace relaxation to those
two boundaries:

- `full_cite` template becomes `r"$volume\s*$reporter,?\s*$page"`
- `_relax_ws` now trims its trailing `\s*` so the reporter group cannot
  capture boundary whitespace (`reporter='U.S. '`) once the mandatory
  template space is gone.

Measured on the 7,740 glued-citation opinions from the bulk scan (details in
#338): 7,737 recovered citations across 4,141 documents, no losses of
previously-extracted citations, existing test suite unchanged. New regression
tests cover glued full/short cites, composition with #305, group cleanliness,
and a non-citation negative.

## AI Disclosure

- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
