### PR TITLE
fix(ci): fix GNU sed syntax in Pdoc workflow and add manual trigger

### DIFF
--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -2,8 +2,9 @@ name: Pdoc
 
 on:
   push:
-      tags:
-        - v*.*.*
+    tags:
+      - v*.*.*
+  workflow_dispatch:
 
 jobs:
   build:
@@ -35,7 +36,7 @@ jobs:
       - name: Run sed  # Removes insanely-long parameter definition from docs
         working-directory: ./api_documentation
         run: |
-          sed -i '' -E 's#(AhocorasickTokenizer\().*(markup_text:)#\1),<br>\2#g' eyecite/find.html eyecite/index.html
+          sed -i -E 's#(AhocorasickTokenizer\().*(markup_text:)#\1),<br>\2#g' eyecite/find.html eyecite/index.html
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Changes:
 - CI: benchmark runs are superseded when a PR is updated, time out after 15 minutes, and pin their third-party action to a commit SHA. #332
 
 Fixes:
+- CI: fix `sed` invocation syntax in the Pdoc workflow on GNU/Linux runners and
+  add `workflow_dispatch` trigger. #316
 - CI: harden the benchmark's `repository_dispatch` job against shell script
   injection by passing `client_payload` values through the environment and
   validating their shape, instead of interpolating them into `run:`. #337


### PR DESCRIPTION
## Fixes
Fixes: #316

## Summary
The Pdoc workflow (`.github/workflows/pdoc.yml`) runs on `ubuntu-latest` (GNU sed), where `sed -i ''` causes sed to treat `''` as an empty script and the following regex argument as a target filename, resulting in `sed: can't read ...: No such file or directory`.

This PR:
1. Removes the macOS-specific `''` argument from `sed -i` so it executes properly under GNU sed.
2. Adds a `workflow_dispatch:` trigger to allow manually re-running the docs build workflow from GitHub Actions without re-pushing/moving release tags.
3. Updates `CHANGES.md`.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.