### PR TITLE
fix: extract USC citations when the section mark is omitted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ Fixes:
 - Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when
   `clean_steps` was omitted or lacked `"html"`. The documented fallback that
   prepends the `html` step was both unreachable and broken.
+- Extract U.S. Code citations written without the section mark, like
+  `50 U.S.C. 1701`. Executive-branch and Federal Register drafting omits the
+  `§`, so those cites were missed entirely. A title and a section number
+  are still both required. #300
 
 ## Current
 

--- a/eyecite/tokenizers.py
+++ b/eyecite/tokenizers.py
@@ -137,6 +137,12 @@ def _populate_reporter_extractors():
     raw_regex_variables = deepcopy(RAW_REGEX_VARIABLES)
     raw_regex_variables["full_cite"][""] = "$volume $reporter,? $page"
     raw_regex_variables["page"][""] = rf"(?P<page>{PAGE_NUMBER_REGEX})"
+    # Executive-branch drafting omits the section mark ("50 U.S.C. 1701"),
+    # so the marker is optional. Only the U.S.C. regex uses this variable,
+    # and it still requires both a title and a section number. See #300.
+    raw_regex_variables["section_marker"] = (
+        rf"(?:{raw_regex_variables['section_marker']})?"
+    )
     regex_variables = process_variables(raw_regex_variables)
 
     def _substitute_edition(template, *edition_names):

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -1019,6 +1019,39 @@ class FindTest(TestCase):
         # fmt: on
         self.run_test_pairs(test_pairs, "Law citation extraction")
 
+    def test_find_usc_citations_without_section_mark(self):
+        """Do we find U.S.C. cites that omit the section mark? (#300)"""
+        # fmt: off
+        test_pairs = (
+            ('50 U.S.C. 1701',
+             [law_citation('50 U.S.C. 1701', reporter='U.S.C.',
+                           groups={'title': '50', 'section': '1701'})]),
+            ('18 U.S.C. 1961',
+             [law_citation('18 U.S.C. 1961', reporter='U.S.C.',
+                           groups={'title': '18', 'section': '1961'})]),
+            # The marked form is unchanged, and is still preferred over the
+            # bare form, so "§ 1701" is not also matched as a second cite.
+            ('50 U.S.C. § 1701',
+             [law_citation('50 U.S.C. § 1701', reporter='U.S.C.',
+                           groups={'title': '50', 'section': '1701'})]),
+            ('50 U.S.C. 1701 et seq.',
+             [law_citation('50 U.S.C. 1701 et seq.', reporter='U.S.C.',
+                           metadata={'pin_cite': 'et seq.'},
+                           groups={'title': '50', 'section': '1701'})]),
+            ('pursuant to the International Emergency Economic Powers Act '
+             '(50 U.S.C. 1701 et seq.)',
+             [law_citation('50 U.S.C. 1701 et seq.', reporter='U.S.C.',
+                           metadata={'pin_cite': 'et seq.'},
+                           groups={'title': '50', 'section': '1701'})]),
+            # Prose mentioning the code needs both a title and a section.
+            ('the U.S.C. is a code', []),
+            ('U.S.C. Title 18', []),
+            ('see U.S.C.', []),
+            ('codified at 50 U.S.C.', []),
+        )
+        # fmt: on
+        self.run_test_pairs(test_pairs, "USC citation without section mark")
+
     def test_find_journal_citations(self):
         """Can we find citations from journals.json?"""
         # fmt: off


### PR DESCRIPTION
## Fixes
Fixes #300

## Summary
Federal Register and executive-order drafting omits the section mark, so
`50 U.S.C. 1701` extracted as nothing while `50 U.S.C. § 1701` worked.

This makes the marker optional in the existing law citation pattern rather
than adding a normalizing pre-pass. The pattern comes from reporters-db via
the `$section_marker` variable, and that variable is used by exactly one of
the 373 law regexes there — the U.S.C. one — so widening it at eyecite's
existing variable-override chokepoint touches only U.S.C. and needs no
hardcoded reporter name. A title and a section number are both still
required, so bare prose mentions of the code do not match. No lookahead is
introduced, so `HyperscanTokenizer` still compiles it.

Lettered sections like `§ 2339B` are unchanged and still unmatched; that is
#146 / #331.

## Tests
`python -m unittest discover -s tests -p 'test_*.py'` → 56 tests, OK.

New test `test_find_usc_citations_without_section_mark` fails on main
(`[] != [FullLawCitation]`) and passes here. It covers the no-§ form, the
§ form still matching once and not twice, `et seq.`, the sentence from the
issue, and four prose negatives (`the U.S.C. is a code`, `U.S.C. Title 18`,
`see U.S.C.`, `codified at 50 U.S.C.`).

Also checked by hand: extraction over `tests/assets/opinion.txt` returns the
same 170 citations before and after.

## AI Disclosure
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
