### PR TITLE
fix: keep the pin cite on an Id. citation that refers to a section

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ Fixes:
 - Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when
   `clean_steps` was omitted or lacked `"html"`. The documented fallback that
   prepends the `html` step was both unreachable and broken.
+- Keep the pin cite on an `Id.` citation that refers to a section, like
+  `Id. § 1985`. The section mark is its own token and used to stop the pin
+  cite scan, so the pin cite was lost and the mark was reported as a separate
+  `UnknownCitation`. #299
 
 ## Current
 

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -19,12 +19,14 @@ from eyecite.models import (
     PlaceholderCitationToken,
     ReferenceCitation,
     ResourceCitation,
+    SectionToken,
     ShortCaseCitation,
     StopWordToken,
     SupraCitation,
     SupraToken,
     Token,
     Tokens,
+    UnknownCitation,
 )
 from eyecite.regexes import (
     POST_FULL_CITATION_REGEX,
@@ -1015,7 +1017,9 @@ def match_on_tokens(
         token = words[index]
 
         # check for stop token
-        if strings_only and not isinstance(token, str):
+        # A section mark is a marker, not a citation: its text is ordinary
+        # pin cite vocabulary, so scanning has to see it rather than stop.
+        if strings_only and not isinstance(token, str | SectionToken):
             break
         if isinstance(token, ParagraphToken):
             break
@@ -1107,6 +1111,11 @@ def filter_citations(citations: list[CitationBase]) -> list[CitationBase]:
             paren = last_citation.metadata.parenthetical
             if paren and citation.matched_text() in paren:
                 filtered_citations.append(citation)
+                continue
+
+            # A section mark the previous citation took as its pin cite
+            # is that pin cite, not a citation of its own.
+            if isinstance(citation, UnknownCitation):
                 continue
 
             # Known overlap case are parallel full citations

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -947,6 +947,44 @@ class FindTest(TestCase):
         self.assertEqual(len(ambiguous.all_editions), 2)
         self.assertEqual(len(set(ambiguous.all_editions)), 2)
 
+    def test_id_citation_with_section_pin_cite(self):
+        """Does an Id. cite keep a section pin cite? (#299)
+
+        The section mark is its own token, and the pin cite scan used to stop
+        at any non-string token, so "Id. § 5" lost the pin cite and left the
+        mark behind as a citation of its own.
+        """
+        # fmt: off
+        test_pairs = (
+            ('42 U.S.C. § 1983. Id. § 1985.',
+             [law_citation('42 U.S.C. § 1983', reporter='U.S.C.',
+                           groups={'title': '42', 'section': '1983'}),
+              id_citation('Id.', metadata={'pin_cite': '§ 1985'})]),
+            ('Foo v. Bar 1 U.S. 12. Id. §§ 5-7.',
+             [case_citation(page='12',
+                            metadata={'plaintiff': 'Foo', 'defendant': 'Bar'}),
+              id_citation('Id.', metadata={'pin_cite': '§§ 5-7'})]),
+            # The mark is glued to the number, so it is one token.
+            ('Foo v. Bar 1 U.S. 12. Id. §5.',
+             [case_citation(page='12',
+                            metadata={'plaintiff': 'Foo', 'defendant': 'Bar'}),
+              id_citation('Id.', metadata={'pin_cite': '§5'})]),
+            ('Foo v. Bar 1 U.S. 12. Id. § 5, 7.',
+             [case_citation(page='12',
+                            metadata={'plaintiff': 'Foo', 'defendant': 'Bar'}),
+              id_citation('Id.', metadata={'pin_cite': '§ 5, 7'})]),
+            # A page pin cite still works.
+            ('Foo v. Bar 1 U.S. 12. Id. at 5.',
+             [case_citation(page='12',
+                            metadata={'plaintiff': 'Foo', 'defendant': 'Bar'}),
+              id_citation('Id.', metadata={'pin_cite': 'at 5'})]),
+            # A mark that no citation absorbs is still reported on its own.
+            ('lorem ipsum see § 99 of the U.S. code.',
+             [unknown_citation('§')]),
+        )
+        # fmt: on
+        self.run_test_pairs(test_pairs, "Id. citation with a section pin cite")
+
     def test_find_law_citations(self):
         """Can we find citations from laws.json?"""
         # fmt: off


### PR DESCRIPTION
## Fixes
Refs #299 — deliberately not `Fixes`, see the note at the end.

## Summary
`Id. § 1985` lost its pin cite, and the section mark was reported as a
separate `UnknownCitation`. A plain `Id. at 5` was always fine, so this only
hit `Id.` cites pointing at a section.

The cause is the one named in the issue: the mark is its own token, and
`match_on_tokens()` stops at any non-string token when `strings_only=True`,
so the scan never saw past it. This is fix option 2 from the issue.

Two changes in `helpers.py`:

- `match_on_tokens()` reads through a `SectionToken` instead of stopping at
  it. The mark is a marker, not a citation, and its text is already pin cite
  vocabulary — `PIN_CITE_TOKEN_REGEX` has listed `§{1,2}` as a label all
  along, it just never got to see one.
- `filter_citations()` drops an `UnknownCitation` that overlaps the citation
  before it. Once the mark is part of the pin cite it is not a citation of
  its own, and this also silences the "Unknown overlap case" warning the
  pairing was logging. A mark inside a parenthetical is still kept, by the
  rule directly above.

## Tests
`python -m unittest discover -s tests -p 'test_*.py'` → 56 tests, OK.

New test `test_id_citation_with_section_pin_cite` fails on main (the stray
`UnknownCitation` is the extra element) and passes here. It covers
`42 U.S.C. § 1983. Id. § 1985.`, `Id. §§ 5-7.`, the glued `Id. §5.` form,
`Id. § 5, 7.`, a guard that `Id. at 5` still works, and a guard that a mark
no citation absorbs is still reported on its own.

`match_on_tokens()` is shared, so I read its six call sites and diffed
behaviour on the neighbours, including the backward scans for party names
and `supra` antecedents: `§ 3.1 (2d ed. 1977), Strawberry Hill, 725 S.W.2d
at 176`, `1 U.S. 1 (citing § 5)`, `§ 5. Adarand, supra, at 240`, `lorem
ipsum see §99 of the U.S. code.`, `Fla. Stat. § 120.68 (2007)`, `Mass. Gen.
Laws ch. 1, §§ 2-3`. All byte-identical before and after. Extraction over
`tests/assets/opinion.txt` is unchanged at 170 citations.

## Why this is `Refs` and not `Fixes`
The example in the issue, `Id. § 394-ccc(2)-(3)`, still does not produce a
pin cite after this change — but for an unrelated reason. `394-ccc` is a
section number with letters in it, which is #146, and #331 is open for it.
Widening `PIN_CITE_TOKEN_REGEX` to swallow that shape would put a statute
section grammar inside the pin cite every case citation uses (`at 5-ccc(2)`
would start matching) and would overlap #331, so I have left it alone.
Say the word if you would rather this close #299 and track the lettered
form solely on #146.

## AI Disclosure
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
