### PR TITLE
fix: read a law citation's bare date parenthetical as a date, not a publisher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ Fixes:
 - Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when
   `clean_steps` was omitted or lacked `"html"`. The documented fallback that
   prepends the `html` step was both unreachable and broken.
+- Read a law citation's bare date parenthetical as a date. In
+  `18 U.S.C. § 1 (May 2, 1999)` the publisher token took the month name, so
+  `publisher` held `"May"` and `month` was empty. A parenthetical opening
+  with a month is no longer read as a publisher. #326
 
 ## Current
 

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -367,6 +367,10 @@ POST_LAW_CITATION_REGEX = rf"""
     (?:\(
         # Consol., McKinney, Deering, West, LexisNexis, etc.
         (?P<publisher>
+            # A parenthetical opening with a month is a bare date. The
+            # publisher token would otherwise take the month name and the
+            # date would lose it.
+            (?!{MONTH_REGEX}[\ ,)])
             [A-Z][a-z]+\.?
             (?:\ Supp\.)?
         )?

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -1019,6 +1019,54 @@ class FindTest(TestCase):
         # fmt: on
         self.run_test_pairs(test_pairs, "Law citation extraction")
 
+    def test_law_citation_bare_date_parenthetical(self):
+        """Is a bare date parenthetical read as a date, not a publisher? (#326)
+
+        The publisher group precedes the month group, so a parenthetical that
+        opens with a month name satisfied the publisher first and the month
+        was left empty.
+        """
+        # fmt: off
+        test_pairs = (
+            ('18 U.S.C. § 1 (May 2, 1999)',
+             [law_citation('18 U.S.C. § 1 (May 2, 1999)', reporter='U.S.C.',
+                           metadata={'month': 'May', 'day': '2'},
+                           groups={'title': '18', 'section': '1'},
+                           year=1999)]),
+            ('18 U.S.C. § 1 (Jan. 1, 2012)',
+             [law_citation('18 U.S.C. § 1 (Jan. 1, 2012)', reporter='U.S.C.',
+                           metadata={'month': 'Jan.', 'day': '1'},
+                           groups={'title': '18', 'section': '1'},
+                           year=2012)]),
+            # Month and year, no day.
+            ('18 U.S.C. § 1 (May 1999)',
+             [law_citation('18 U.S.C. § 1 (May 1999)', reporter='U.S.C.',
+                           metadata={'month': 'May'},
+                           groups={'title': '18', 'section': '1'},
+                           year=1999)]),
+            # A publisher before the month was always read correctly.
+            ('18 U.S.C. § 1 (West Jan. 1, 2012)',
+             [law_citation('18 U.S.C. § 1 (West Jan. 1, 2012)',
+                           reporter='U.S.C.',
+                           metadata={'publisher': 'West', 'month': 'Jan.',
+                                     'day': '1'},
+                           groups={'title': '18', 'section': '1'},
+                           year=2012)]),
+            ('18 U.S.C. § 1 (West 1999)',
+             [law_citation('18 U.S.C. § 1 (West 1999)', reporter='U.S.C.',
+                           metadata={'publisher': 'West'},
+                           groups={'title': '18', 'section': '1'},
+                           year=1999)]),
+            # A publisher that merely starts with a month name is not a date.
+            ('18 U.S.C. § 1 (Mayhew 1999)',
+             [law_citation('18 U.S.C. § 1 (Mayhew 1999)', reporter='U.S.C.',
+                           metadata={'publisher': 'Mayhew'},
+                           groups={'title': '18', 'section': '1'},
+                           year=1999)]),
+        )
+        # fmt: on
+        self.run_test_pairs(test_pairs, "Law citation bare date parenthetical")
+
     def test_find_journal_citations(self):
         """Can we find citations from journals.json?"""
         # fmt: off


### PR DESCRIPTION
## Fixes
Fixes #326

## Summary
`18 U.S.C. § 1 (May 2, 1999)` stored `publisher="May"` and left `month`
empty. The publisher group sits before the month group in
`POST_LAW_CITATION_REGEX`, so a leading month name satisfied the publisher
token first and the month subpattern never saw it. `(West Jan. 1, 2012)`
was always right, because a real publisher came first.

This is the direction suggested in the issue: a negative lookahead keeps the
publisher token off a month name. The same trick already appears a few lines
up in `POST_FULL_CITATION_REGEX`, which uses a `MONTH_REGEX` lookahead to
stop the court group from swallowing a date.

The month has to be followed by a space, a comma, or the closing paren, so a
publisher that merely starts with a month name — `(Mayhew 1999)` — is still
a publisher.

One incidental change: `(May)` on its own is now a parenthetical rather than
`publisher="May"`, which seems the better of the two readings.

## Tests
`python -m unittest discover -s tests -p 'test_*.py'` → 56 tests, OK.

New test `test_law_citation_bare_date_parenthetical` fails on main
(`publisher='May'` vs `publisher=None`) and passes here. It covers
`(May 2, 1999)`, `(Jan. 1, 2012)`, the day-less `(May 1999)`, the
`(West Jan. 1, 2012)` and `(West 1999)` controls that already worked, and
`(Mayhew 1999)` as the false positive.

Diffed metadata across the surrounding law parentheticals before and after:
`(Lexis Jun. 2018)`, `(Consol. 1999)`, `(West)`, `(2007)`,
`(West 2009)` with `et seq.`, `(Lexis Supp. 2010)`, `(2005-06)`,
`(repealed) (ignore this)`, `(1987)`, plus `410 U.S. 113 (1973)` and
`Foo v. Bar, 1 U.S. 1 (May 2, 1999)`. Only the bare-date rows change.
Extraction over `tests/assets/opinion.txt` is unchanged at 170 citations.

## Note on #330
#330 is open against these same lines for #325 and rewrites the publisher
character class. The two changes are orthogonal — this one adds a lookahead
in front of the token, that one widens what the token accepts — but whichever
lands second will want a rebase. Merge #330 first and I will rebase this on
top.

## AI Disclosure
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
