### PR TITLE
fix: keep statute "note" as a distinct citation identity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,11 @@ Fixes:
 - Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when
   `clean_steps` was omitted or lacked `"html"`. The documented fallback that
   prepends the `html` step was both unreachable and broken.
+- Keep a statute's trailing `note` designator as part of the citation's
+  identity. A note is a different provision than the section it is filed
+  under, so `42 U.S.C. § 1983 note` now carries `groups["note"]` and no
+  longer resolves to the bare `42 U.S.C. § 1983`. Prose such as
+  "§ 1983 notes that ..." is not treated as a designator. #323
 
 ## Current
 

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -890,6 +890,10 @@ def add_law_metadata(citation: FullLawCitation, words: Tokens) -> None:
         return
 
     citation.full_span_end = citation.span()[1] + m.end()
+    # A note is a different provision than the section it is filed under, so it
+    # belongs to the citation's identity, which is built from groups.
+    if m["note"]:
+        citation.groups["note"] = m["note"]
     citation.metadata.pin_cite = clean_pin_cite(m["pin_cite"]) or None
     citation.metadata.publisher = m["publisher"]
     citation.metadata.day = m["day"]

--- a/eyecite/models.py
+++ b/eyecite/models.py
@@ -408,6 +408,8 @@ class FullLawCitation(FullCitation):
         m = self.metadata
         if m.pin_cite:
             parts.append(f"{m.pin_cite}")
+        if note := self.groups.get("note"):
+            parts.append(f" {note}")
         publisher_date = " ".join(
             i for i in (m.publisher, m.month, m.day, m.year) if i
         )

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -259,6 +259,22 @@ LAW_PIN_CITE_REGEX = rf"""
     )
 """
 
+# Law note regex:
+# A trailing "note" points at material filed under a section rather than at the
+# section itself, so it is a different target and not a pin cite. Unlike
+# "et seq." the word is ordinary English, so it only counts as a designator
+# when nothing continues it: "notes that ..." must not match.
+LAW_NOTE_REGEX = r"""
+    (?:
+        \ (?P<note>note)
+        (?=
+            [,.;)\]\\]|  # ending punctuation
+            \ ?[(\[]|    # space and start of parens
+            $            # end of text
+        )
+    )?
+"""
+
 # Short cite antecedent regex:
 # What case does a short cite refer to? For now, we just capture the previous
 # word optionally followed by a comma. Example: Adarand, 515 U.S. at 241.
@@ -363,6 +379,7 @@ POST_SHORT_CITATION_REGEX = rf"""
 # and then may be followed by a parenthetical:
 POST_LAW_CITATION_REGEX = rf"""
     {LAW_PIN_CITE_REGEX}?
+    {LAW_NOTE_REGEX}
     \ ?
     (?:\(
         # Consol., McKinney, Deering, West, LexisNexis, etc.

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -1015,6 +1015,43 @@ class FindTest(TestCase):
              [law_citation('Mass. Gen. Laws ch. 1, §§ 2-3',
                            reporter='Mass. Gen. Laws',
                            groups={'chapter': '1', 'section': '2-3'})]),
+            # note designator, a different provision than the section
+            ('42 U.S.C. § 1983 note',
+             [law_citation('42 U.S.C. § 1983 note', reporter='U.S.C.',
+                           groups={'title': '42', 'section': '1983',
+                                   'note': 'note'})]),
+            ('28 U.S.C. § 994 note',
+             [law_citation('28 U.S.C. § 994 note', reporter='U.S.C.',
+                           groups={'title': '28', 'section': '994',
+                                   'note': 'note'})]),
+            ('8 U.S.C. § 1101 note',
+             [law_citation('8 U.S.C. § 1101 note', reporter='U.S.C.',
+                           groups={'title': '8', 'section': '1101',
+                                   'note': 'note'})]),
+            # note after a subsection pin cite
+            ('Fla. Stat. § 120.68(2) note',
+             [law_citation('Fla. Stat. § 120.68(2) note',
+                           reporter='Fla. Stat.',
+                           metadata={'pin_cite': '(2)'},
+                           groups={'section': '120.68', 'note': 'note'})]),
+            # note before a year parenthetical
+            ('42 U.S.C. § 1983 note (1994)',
+             [law_citation('42 U.S.C. § 1983 note (1994)', reporter='U.S.C.',
+                           groups={'title': '42', 'section': '1983',
+                                   'note': 'note'},
+                           year=1994)]),
+            # et seq. is part of the section, so it stays a pin cite
+            ('42 U.S.C. § 1983 et seq.',
+             [law_citation('42 U.S.C. § 1983 et seq.', reporter='U.S.C.',
+                           metadata={'pin_cite': 'et seq.'},
+                           groups={'title': '42', 'section': '1983'})]),
+            # "note" as prose, not a designator
+            ('42 U.S.C. § 1983 notes that liability attaches',
+             [law_citation('42 U.S.C. § 1983', reporter='U.S.C.',
+                           groups={'title': '42', 'section': '1983'})]),
+            ('42 U.S.C. § 1983. Note that the court',
+             [law_citation('42 U.S.C. § 1983', reporter='U.S.C.',
+                           groups={'title': '42', 'section': '1983'})]),
         )
         # fmt: on
         self.run_test_pairs(test_pairs, "Law citation extraction")

--- a/tests/test_ModelsTest.py
+++ b/tests/test_ModelsTest.py
@@ -158,6 +158,18 @@ class ModelsTest(TestCase):
         self.assertNotEqual(hash(citations[0]), hash(citations[1]))
         print("✓")
 
+    def test_law_note_comparison(self):
+        """Is a statutory note a different citation than the section it is
+        filed under?"""
+        citations = [
+            get_citations("42 U.S.C. § 1983")[0],
+            get_citations("42 U.S.C. § 1983 note")[0],
+        ]
+        print("Testing law note comparison...", end=" ")
+        self.assertNotEqual(citations[0], citations[1])
+        self.assertNotEqual(hash(citations[0]), hash(citations[1]))
+        print("✓")
+
     def test_missing_page_cite_conversion(self):
         """Do citations with missing page numbers get their groups['page']
         attribute set to None?"""
@@ -220,6 +232,14 @@ class ModelsTest(TestCase):
         self.assertEqual(
             full_case_citation.corrected_citation_full(),
             "Meritor Sav. Bank v. Vinson, 477 U.S. 57, 60 (scotus 1986)",
+        )
+
+    def test_corrected_full_citation_includes_law_note(self):
+        """Does the corrected_citation_full method keep a note designator?"""
+        law_note_citation = get_citations("42 U.S.C. § 1983 note")[0]
+        self.assertEqual(
+            law_note_citation.corrected_citation_full(),
+            "42 U.S.C. § 1983 note",
         )
 
     def test_page_correction(self):


### PR DESCRIPTION
## Fixes
Fixes #323

## Summary
`42 U.S.C. § 1983 note` is a different provision than `42 U.S.C. § 1983`. A note holds
enacted-but-uncodified material filed under the nearest section, so the section number is
an address, not an identity. eyecite dropped the designator, and the two citations came
back equal.

The designator now lands in `groups` rather than `metadata`. That is deliberate:
`ResourceCitation.__hash__` is built from `groups`, so a `note: bool` field would have
needed its own `__hash__` override on `FullLawCitation` to affect identity, while one
group key reuses the identity vocabulary the model already has. `section` keeps its plain
section number and no existing key changes value.

`et seq.` is untouched and stays a `pin_cite`, because it really is part of the section.

Because "note" is ordinary English, `LAW_NOTE_REGEX` only matches when nothing continues
it — end of text, or `.` `,` `;` `)` `(` or a year parenthetical — and only lowercase,
directly after the cite. So `§ 1983 notes that liability attaches` and
`§ 1983. Note that the court` do not attach. Both are in the tests, and both go red if
the guard is removed.

The issue's third example, `42 U.S.C. § 5195c(b) note`, is still a miss. That is the
lettered-section tokenizer problem in #146 (PR #331), not this one, so it is left alone.

## Tests
- `python -m unittest tests.test_FindTest.FindTest.test_find_law_citations` — 15 failures
  before the change (5 new rows x 3 tokenizers), passes after.
- `python -m unittest tests.test_ModelsTest` — the two new tests failed before with
  `FullLawCitation('42 U.S.C. § 1983') == FullLawCitation('42 U.S.C. § 1983')` and
  `'42 U.S.C. § 1983' != '42 U.S.C. § 1983 note'`.
- `python -m unittest discover -s tests -p 'test_*.py'` — 57 tests, OK.
- `pre-commit run --all-files` and `mypy .` — clean.

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
