### PR TITLE
fix(regex): keep the court group inside its own parenthetical

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@ Changes:
 - CI: benchmark runs are superseded when a PR is updated, time out after 15 minutes, and pin their third-party action to a commit SHA. #332
 
 Fixes:
+- Stop the court group of `POST_FULL_CITATION_REGEX` from running past a
+  citation's own `(year)` paren into a later `(court year)` paren, which
+  mis-set `year`, `court` and `full_span` on string cites and on citations
+  followed by another citation in the next sentence.
 - CI: harden the benchmark's `repository_dispatch` job against shell script
   injection by passing `client_payload` values through the environment and
   validating their shape, instead of interpolating them into `run:`. #337

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -308,7 +308,7 @@ POST_FULL_CITATION_REGEX = rf"""
         [\(\[] # opening paren or bracket
         (?:
             (?:
-                (?P<court>.*?) # treat anything before date as court
+                (?P<court>[^()]*?) # treat anything before date as court
                 (?= # lookahead to stop when we see a month or year
                     \s+{MONTH_REGEX} |
                     \s+{YEAR_REGEX}

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -2102,3 +2102,32 @@ class FindTest(TestCase):
         citations = get_citations(text)
         self.assertEqual(len(citations), 2)
         mock_warn.assert_not_called()
+
+    def test_court_year_paren_does_not_run_on(self):
+        """The court group must stop at ")" instead of crawling into a later
+        court/date parenthetical. Before the fix the first case reported
+        year=1997 and a full_span reaching the end of the string."""
+        cases = [
+            (
+                "A v. B, 550 U.S. 544, 555 (2007). Later text here (2d Cir. 1997).",
+                2007, "scotus", "A v. B, 550 U.S. 544, 555 (2007)",
+            ),
+            (
+                "See, e.g., A v. B, 550 U.S. 544, 555 (2007); C v. D, 123 F.3d 456, 460 (2d Cir. 1997).",
+                2007, "scotus", "A v. B, 550 U.S. 544, 555 (2007)",
+            ),
+            (
+                "Thole v. U.S. Bank, 590 U.S. 538 (2020). Doe v. Roe, 45 F. Supp. 3d 100 (S.D.N.Y. Feb. 9, 2014).",
+                2020, "scotus", "Thole v. U.S. Bank, 590 U.S. 538 (2020)",
+            ),
+            (
+                "A v. B, 123 F.3d 456, 460 (2d Cir. Feb. 9, 1997) (holding x).",
+                1997, "ca2", "A v. B, 123 F.3d 456, 460 (2d Cir. Feb. 9, 1997) (holding x)",
+            ),
+        ]
+        for text, year, court, full in cases:
+            with self.subTest(text=text):
+                cite = get_citations(text)[0]
+                self.assertEqual(cite.year, year)
+                self.assertEqual(cite.metadata.court, court)
+                self.assertEqual(text[slice(*cite.full_span())], full)


### PR DESCRIPTION
## Fixes
Fixes court/year/`full_span` mis-association on string cites and on citations followed by another citation in the next sentence.

## Summary
`POST_FULL_CITATION_REGEX` captured the court as `(?P<court>.*?)` followed by a lookahead for whitespace plus a month or year. When a citation's own year paren is `(2007)` there is no whitespace before the digits, so the lazy court group crawled forward across `2007). Later text (2d Cir.` until it found ` 1997`.

Fix: `(?P<court>[^()]*?)`. Adds `FindTest.test_court_year_paren_does_not_run_on` covering four string-cite variants. Eyecite suite stays green (56 tests).

Defining input:
```
A v. B, 550 U.S. 544, 555 (2007). Later text here (2d Cir. 1997).
   -> year=2007, full_span = "A v. B, 550 U.S. 544, 555 (2007)"
```

## AI Disclosure
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.