### PR TITLE
fix(helpers): prevent citation metadata bleeding across neighboring citations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Fixes:
   `clean_steps` was omitted or lacked `"html"`. The documented fallback that
   prepends the `html` step was both unreachable and broken.
 - Add missing stop word "compare". #321
+- Identify boundary when reaching second citation parenthetical year. #321
 
 ## Current
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Fixes:
 - Fix 2 `TypeError`s raised in `get_citations(markup_text=...)` when
   `clean_steps` was omitted or lacked `"html"`. The documented fallback that
   prepends the `html` step was both unreachable and broken.
+- Add missing stop word "compare". #321
 
 ## Current
 

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -373,7 +373,9 @@ def _process_case_name(
         else:
             plaintiff, defendant = "", splits[0]
         plaintiff = plaintiff.strip(f"{whitespace},(")
-        clean_plaintiff = re.sub(r"\b[a-z]\w*\b", "", plaintiff)
+        clean_plaintiff = re.sub(
+            r"\b(?!(?:of|and)\b)[a-z]\w*\b", "", plaintiff
+        )
         plaintiff = strip_stop_words(clean_plaintiff)
         citation.metadata.plaintiff = plaintiff
     else:

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -227,6 +227,12 @@ def _scan_for_case_boundaries(
 
         # Handle year before citation
         if re.match(r"\(\d{4}\)", word_str):
+            if state["v_token"] is not None:
+                # A year found after the v_token must belong to an earlier
+                # citation, unrelated to the one that is already completed
+                # in this iteration.
+                break
+
             state["title_starting_index"] = index - 1
             state["pre_cite_year"] = word_str[1:5]
             continue

--- a/eyecite/helpers.py
+++ b/eyecite/helpers.py
@@ -231,6 +231,10 @@ def _scan_for_case_boundaries(
                 # A year found after the v_token must belong to an earlier
                 # citation, unrelated to the one that is already completed
                 # in this iteration.
+                state["start_index"] = index + 2
+                state["candidate_case_name"] = _extract_text(
+                    words, state["start_index"], state["title_starting_index"]
+                )
                 break
 
             state["title_starting_index"] = index - 1

--- a/eyecite/regexes.py
+++ b/eyecite/regexes.py
@@ -90,6 +90,7 @@ STOP_WORDS = (
     "granted",
     "dismissed",
     "Cf",
+    "compare",
 )
 STOP_WORD_REGEX = space_boundaries_re(
     strip_punctuation_re(rf"(?P<stop_word>{'|'.join(STOP_WORDS)})")

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -866,6 +866,20 @@ class FindTest(TestCase):
                                       "defendant": "Board of Education",
                                       "year": "1954"}
                             ),
+              ]),
+            # Multi-words plaintiff before another citation year
+            ("Smith v. Jones, 347 U.S. 999 (1952). Association Citizens United v. FEC, 558 U.S. 310 (2010).",
+             [case_citation(volume="347", reporter="U.S.", page="999",
+                            metadata={"plaintiff": "Smith",
+                                      "defendant": "Jones",
+                                      "year": "1952"}
+                            ),
+              case_citation(volume="558", reporter="U.S.", page="310",
+                            metadata={
+                                "plaintiff": "Association Citizens United",
+                                "defendant": "FEC",
+                                "year": "2010"}
+                            ),
               ])
         )
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -880,6 +880,20 @@ class FindTest(TestCase):
                                 "defendant": "FEC",
                                 "year": "2010"}
                             ),
+              ]),
+            # Plaintiff name including exceptional lowercase-only words ('of', 'and')
+            ("Smith v. Jones, 347 U.S. 999 (1952). Trustees of Dartmouth College v. Woodward, 17 U.S. 518 (1819).",
+             [case_citation(volume="347", reporter="U.S.", page="999",
+                            metadata={"plaintiff": "Smith",
+                                      "defendant": "Jones",
+                                      "year": "1952"}
+                            ),
+              case_citation(volume="17", reporter="U.S.", page="518",
+                            metadata={
+                                "plaintiff": "Trustees of Dartmouth College",
+                                "defendant": "Woodward",
+                                "year": "1819"}
+                            ),
               ])
         )
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -835,7 +835,24 @@ class FindTest(TestCase):
                             metadata={"plaintiff": "Crane",
                                       "defendant": "Hyde Park"}
                             )],
-             {'clean_steps': ['html', 'inline_whitespace']})
+             {'clean_steps': ['html', 'inline_whitespace']}),
+            ("The court in Smith v. Jones, 347 U.S. 999 (1951), held that \"schools must serve pizza.\" Smith v. Jones, 347 U.S. 999 (1952). Compare Brown v. Board of Education, 347 U.S. 483 (1954).",
+             [case_citation(volume="347", reporter="U.S.", page="999",
+                            metadata={"plaintiff": "Smith",
+                                      "defendant": "Jones",
+                                      "year": "1951"}
+                            ),
+              case_citation(volume="347", reporter="U.S.", page="999",
+                            metadata={"plaintiff": "Smith",
+                                      "defendant": "Jones",
+                                      "year": "1952"}
+                            ),
+              case_citation(volume="347", reporter="U.S.", page="483",
+                            metadata={"plaintiff": "Brown",
+                                      "defendant": "Board of Education",
+                                      "year": "1954"}
+                            ),
+              ])
         )
 
         # fmt: on

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -836,6 +836,7 @@ class FindTest(TestCase):
                                       "defendant": "Hyde Park"}
                             )],
              {'clean_steps': ['html', 'inline_whitespace']}),
+            # Handle "compare" stop word
             ("The court in Smith v. Jones, 347 U.S. 999 (1951), held that \"schools must serve pizza.\" Smith v. Jones, 347 U.S. 999 (1952). Compare Brown v. Board of Education, 347 U.S. 483 (1954).",
              [case_citation(volume="347", reporter="U.S.", page="999",
                             metadata={"plaintiff": "Smith",
@@ -843,6 +844,19 @@ class FindTest(TestCase):
                                       "year": "1951"}
                             ),
               case_citation(volume="347", reporter="U.S.", page="999",
+                            metadata={"plaintiff": "Smith",
+                                      "defendant": "Jones",
+                                      "year": "1952"}
+                            ),
+              case_citation(volume="347", reporter="U.S.", page="483",
+                            metadata={"plaintiff": "Brown",
+                                      "defendant": "Board of Education",
+                                      "year": "1954"}
+                            ),
+              ]),
+            # Break citation extraction when finding another citation year
+            ("Smith v. Jones, 347 U.S. 999 (1952). Brown v. Board of Education, 347 U.S. 483 (1954).",
+             [case_citation(volume="347", reporter="U.S.", page="999",
                             metadata={"plaintiff": "Smith",
                                       "defendant": "Jones",
                                       "year": "1952"}


### PR DESCRIPTION
## Description

Fixes both repros in #321: `FullCaseCitation.metadata` picking up the **previous** citation's plaintiff/defendant, and separately its **year**, instead of its own.

### Fix 1 — missing stop word

When scanning backward from a citation to find its case name, eyecite stops the scan as soon as it hits a known "stop word" (`STOP_WORD_REGEX` / `STOP_WORDS` in `eyecite/regexes.py`) such as `see`, `accord`, `cf`, etc. If
the text immediately before a citation isn't a recognized stop word, the backward scan keeps walking past the sentence boundary and can pick up the **previous** citation's plaintiff/defendant as this citation's case name.

`compare` (as in `Compare X v. Y ... with A v. B ...` signal phrases) was missing from `STOP_WORDS`, so a citation introduced with `Compare` had nothing to stop the backward scan, and it inherited the prior citation's defendant instead of its own.

```python
from eyecite import get_citations
from eyecite.tokenizers import AhocorasickTokenizer

text = (
    'The court in Smith v. Jones, 347 U.S. 999 (1954), held that '
    '"schools must serve pizza." Smith v. Jones, 347 U.S. 999 (1954). '
    'Compare Brown v. Board of Education, 347 U.S. 483 (1954).'
)
for c in get_citations(text, tokenizer=AhocorasickTokenizer()):
    print(c.corrected_citation(), repr(c.metadata.plaintiff), repr(c.metadata.defendant))
```

Before:
```
347 U.S. 999 'Smith' 'Jones'
347 U.S. 999 'Smith' 'Jones'
347 U.S. 483 ''      'Jones'      # <- Brown's cite, defendant leaked from the prior sentence
```

After:
```
347 U.S. 999 'Smith' 'Jones'
347 U.S. 999 'Smith' 'Jones'
347 U.S. 483 'Brown' 'Board of Education'
```

**Fix:** add `compare` to `STOP_WORDS` in `eyecite/regexes.py` so the backward case-name scan stops there instead of crossing into the previous citation's text, the same mechanism `see`/`accord`/`cf` already rely on.

### Fix 2 — year leaking from the previous citation's parenthetical

The same backward scan in `_scan_for_case_boundaries` (`eyecite/helpers.py`) also picks up a `(YYYY)` year token as it walks past the citation it's building a case name for. It didn't distinguish between a year parenthetical that belongs to *this* citation (appearing before the `v.` token) and one that belongs to an *earlier* citation in the text
(appearing after the `v.` token has already been seen, i.e. the year is on the far side of a case name the scan has already fully consumed). As a result, a citation could silently inherit the previous citation's year instead of using its own trailing `(YYYY)`.

```python
text = "Miranda v. Arizona, 347 U.S. 483 (1990). NLRB v. IBEW, 346 U.S. 464 (1953)."
for c in get_citations(text, tokenizer=AhocorasickTokenizer()):
    print(c.corrected_citation(), c.metadata.year)
```

Before:
```
347 U.S. 483 1990
346 U.S. 464 1990        # <- text says (1953) immediately after this cite
```

After:
```
347 U.S. 483 1990
346 U.S. 464 1953
```

**Fix:** in `_scan_for_case_boundaries`, once a `v_token` has been recorded for the current citation, hitting another `(YYYY)` token means the scan has crossed into an earlier citation's parenthetical — so the loop now breaks
instead of overwriting `pre_cite_year` with that unrelated year.

Both fixes are covered by new cases added to `tests/test_FindTest.py`.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
